### PR TITLE
:bug: fix(ci): Release 上传 glob 匹配实际文件而非目录名

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,6 +149,6 @@ jobs:
           body: ${{ github.event.head_commit.message }}
           files: |
             release-artifacts/**/*.exe
-            release-artifacts/yaoxiang-*
+            release-artifacts/**/yaoxiang
           draft: false
           prerelease: false


### PR DESCRIPTION
release-artifacts/yaoxiang-* 匹配的是目录名，Linux/macOS 的二进制文件没有被上传到 Release。改为 release-artifacts/**/yaoxiang 匹配实际文件。