### PR TITLE
:wrench: chore(ci): Release 容忍部分构建失败

### DIFF
--- a/.github/workflows/_build-platforms.yml
+++ b/.github/workflows/_build-platforms.yml
@@ -29,6 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
+      fail-fast: false
       matrix:
         target: [x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu]
     steps:
@@ -73,6 +74,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 15
     strategy:
+      fail-fast: false
       matrix:
         target: [x86_64-apple-darwin, aarch64-apple-darwin]
     steps:
@@ -111,8 +113,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
+      fail-fast: false
       matrix:
-        target: [x86_64-pc-windows-gnu, aarch64-pc-windows-gnullvm]
+        target: [x86_64-pc-windows-gnu]
     steps:
       - uses: actions/checkout@v4
 
@@ -131,12 +134,6 @@ jobs:
             mingw-w64-tools \
             gcc-mingw-w64-x86-64 \
             g++-mingw-w64-x86-64
-
-      - name: Install LLVM toolchain (aarch64)
-        if: matrix.target == 'aarch64-pc-windows-gnullvm'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y lld llvm
 
       - name: Cache cargo
         uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
     needs: check-version
     if: needs.check-version.outputs.should-release == 'true'
     uses: ./.github/workflows/_build-platforms.yml
+    continue-on-error: true
     with:
       build-profile: release
       artifact-prefix: yaoxiang
@@ -58,6 +59,7 @@ jobs:
     needs: check-version
     if: needs.check-version.outputs.should-release == 'true'
     uses: ./.github/workflows/_build-wasm.yml
+    continue-on-error: true
     with:
       artifact-name: yaoxiang-wasm
       retention-days: 30
@@ -124,7 +126,7 @@ jobs:
   release:
     name: Publish Release
     needs: [check-version, build, build-wasm, security, test]
-    if: always() && needs.check-version.outputs.should-release == 'true' && needs.build.result == 'success' && needs.build-wasm.result == 'success' && needs.security.result == 'success' && needs.test.result == 'success'
+    if: always() && needs.check-version.outputs.should-release == 'true' && !cancelled() && needs.security.result == 'success' && needs.test.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -143,12 +145,14 @@ jobs:
           git push origin "$TAG"
 
       - name: Download all artifacts
+        id: download
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           path: release-artifacts
 
       - name: List artifacts
-        run: ls -R release-artifacts
+        run: ls -R release-artifacts || echo "No artifacts found"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -160,5 +164,6 @@ jobs:
             release-artifacts/**/*.exe
             release-artifacts/**/yaoxiang
             release-artifacts/**/*.wasm
+          fail_on_unmatched_files: false
           draft: false
           prerelease: false


### PR DESCRIPTION
## 变更

- 移除 `aarch64-pc-windows-gnullvm` target（Z3 无预编译二进制 + 链接器不可用）
- 所有构建矩阵加 `fail-fast: false`，各 target 独立构建
- `build` 和 `build-wasm` 加 `continue-on-error: true`
- Release job 条件放宽：只要 security + test 通过即可发版
- download-artifact 加 `continue-on-error: true`，下载失败不影响已成功的 artifact
- release-gh-release 加 `fail_on_unmatched_files: false`，只上传已有文件