### PR TITLE
:wrench: chore(ci): continue-on-error 修复

### DIFF
--- a/.github/workflows/_build-platforms.yml
+++ b/.github/workflows/_build-platforms.yml
@@ -28,6 +28,7 @@ jobs:
     name: Linux (${{ matrix.target }})
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
@@ -73,6 +74,7 @@ jobs:
     name: macOS (${{ matrix.target }})
     runs-on: macos-latest
     timeout-minutes: 15
+    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
@@ -112,6 +114,7 @@ jobs:
     name: Windows (${{ matrix.target }})
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
@@ -161,6 +164,7 @@ jobs:
     name: Windows Installer
     runs-on: windows-latest
     timeout-minutes: 20
+    continue-on-error: true
     if: inputs.build-profile == 'release'
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,6 @@ jobs:
     needs: check-version
     if: needs.check-version.outputs.should-release == 'true'
     uses: ./.github/workflows/_build-platforms.yml
-    continue-on-error: true
     with:
       build-profile: release
       artifact-prefix: yaoxiang
@@ -60,7 +59,6 @@ jobs:
     needs: check-version
     if: needs.check-version.outputs.should-release == 'true'
     uses: ./.github/workflows/_build-wasm.yml
-    continue-on-error: true
     with:
       artifact-name: yaoxiang-wasm
       retention-days: 30


### PR DESCRIPTION
continue-on-error 不能用在 reusable workflow 调用处，移至内部 jobs