### PR TITLE
:wrench: chore(ci): CI/CD 重构——职责分离

### DIFF
--- a/.github/workflows/_build-platforms.yml
+++ b/.github/workflows/_build-platforms.yml
@@ -24,57 +24,6 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  # ── Z3 wasm 预构件 ──────────────────────────────────────────────
-  build-z3-wasm:
-    name: Build Z3 (wasm)
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - name: Checkout Z3 source
-        uses: actions/checkout@v4
-        with:
-          repository: Z3Prover/z3
-          ref: z3-4.16.0
-          path: z3-src
-
-      - name: Setup Emscripten
-        uses: mymindstorm/setup-emsdk@v14
-        with:
-          version: latest
-
-      - name: Configure Z3 with Emscripten
-        run: |
-          mkdir -p z3-build
-          cd z3-build
-          emcmake cmake ../z3-src \
-            -G Ninja \
-            -DZ3_BUILD_LIBZ3_SHARED=OFF \
-            -DZ3_BUILD_EXECUTABLE=OFF \
-            -DZ3_BUILD_TEST_EXECUTABLES=OFF \
-            -DZ3_SAVE_PARSER=OFF \
-            -DZ3_ENABLE_EXAMPLE_TARGETS=OFF \
-            -DZ3_ENABLE_TRACING=OFF \
-            -DZ3_USE_LIB_GMP=OFF \
-            -DCMAKE_BUILD_TYPE=Release
-
-      - name: Build Z3
-        run: cd z3-build && ninja z3
-
-      - name: Prepare artifact
-        run: |
-          mkdir -p dist/lib dist/include
-          cp z3-build/lib/libz3.a dist/lib/ 2>/dev/null || \
-            find z3-build -name "libz3.a" -exec cp {} dist/lib/ \;
-          cp z3-src/src/api/z3.h dist/include/
-          cp z3-src/src/api/z3_api.h dist/include/ 2>/dev/null || true
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: z3-wasm-4.16.0
-          path: dist/
-          retention-days: 90
-
   # ── Linux ───────────────────────────────────────────────────────
   build-linux:
     name: Linux (${{ matrix.target }})
@@ -206,7 +155,7 @@ jobs:
         if: matrix.target == 'aarch64-pc-windows-gnullvm'
         run: |
           sudo apt-get update
-          sudo apt-get install -y clang lld llvm
+          sudo apt-get install -y clang lld llvm gcc-mingw-w64-aarch64 g++-mingw-w64-aarch64
 
       - name: Configure linker (aarch64)
         if: matrix.target == 'aarch64-pc-windows-gnullvm'
@@ -296,62 +245,4 @@ jobs:
         with:
           name: ${{ inputs.artifact-prefix }}-windows-installer
           path: dist/YaoXiang-Setup-*.exe
-          retention-days: ${{ inputs.retention-days }}
-
-  # ── Wasm ────────────────────────────────────────────────────────
-  build-wasm:
-    name: Build Wasm
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    needs: build-z3-wasm
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ vars.RUST_TOOLCHAIN }}
-          targets: wasm32-unknown-unknown
-
-      - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-
-      - name: Download Z3 wasm
-        uses: actions/download-artifact@v4
-        with:
-          name: z3-wasm-4.16.0
-          path: .z3/z3-4.16.0-wasm
-        continue-on-error: true
-
-      - name: Verify Z3 wasm
-        run: |
-          if [ -f ".z3/z3-4.16.0-wasm/lib/libz3.a" ]; then
-            echo "Z3 wasm found"
-          else
-            echo "Z3 wasm not found, Z3 features disabled"
-          fi
-
-      - name: Cache cargo
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry/index
-            ~/.cargo/registry/cache
-            ~/.cargo/git/db
-            target
-          key: wasm-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            wasm-cargo-
-
-      - name: Build Wasm
-        run: cd wasm && wasm-pack build --target web --out-name yaoxiang --out-dir ../pkg
-
-      - name: Package wasm
-        run: cd pkg && zip -r ../yaoxiang-wasm.zip .
-
-      - name: Upload wasm artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ inputs.artifact-prefix }}-wasm
-          path: yaoxiang-wasm.zip
           retention-days: ${{ inputs.retention-days }}

--- a/.github/workflows/_build-wasm.yml
+++ b/.github/workflows/_build-wasm.yml
@@ -6,28 +6,20 @@ on:
       artifact-name:
         description: 'Artifact name'
         type: string
-        default: 'wasm-playground'
+        default: 'yaoxiang-wasm'
       retention-days:
         description: 'Artifact retention days'
         type: number
-        default: 7
-      z3-version:
-        description: 'Z3 version for wasm linking'
-        type: string
-        default: '4.16.0'
-    outputs:
-      artifact-name:
-        description: 'Name of the uploaded artifact'
-        value: ${{ inputs.artifact-name }}
+        default: 30
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build-wasm:
+  build:
     name: Build Wasm
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -40,17 +32,18 @@ jobs:
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
-      - name: Download Z3 wasm
-        uses: actions/download-artifact@v4
+      - name: Download Z3 wasm (cross-run)
+        uses: dawidd6/action-download-artifact@v4
         with:
-          name: z3-wasm-${{ inputs.z3-version }}
-          path: .z3/z3-${{ inputs.z3-version }}-wasm
+          workflow: _build-z3-wasm.yml
+          name: z3-wasm-4.16.0
+          path: .z3/z3-4.16.0-wasm
         continue-on-error: true
 
       - name: Verify Z3 wasm
         run: |
-          if [ -f ".z3/z3-${{ inputs.z3-version }}-wasm/lib/libz3.a" ]; then
-            echo "Z3 wasm found, linking enabled"
+          if [ -f ".z3/z3-4.16.0-wasm/lib/libz3.a" ]; then
+            echo "Z3 wasm found"
           else
             echo "Z3 wasm not found, Z3 features disabled"
           fi
@@ -70,11 +63,12 @@ jobs:
       - name: Build Wasm
         run: cd wasm && wasm-pack build --target web --out-name yaoxiang --out-dir ../pkg
 
+      - name: Package wasm
+        run: cd pkg && zip -r ../yaoxiang-wasm.zip .
+
       - name: Upload wasm artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.artifact-name }}
-          path: |
-            pkg/yaoxiang.js
-            pkg/yaoxiang_bg.wasm
+          path: yaoxiang-wasm.zip
           retention-days: ${{ inputs.retention-days }}

--- a/.github/workflows/_build-z3-wasm.yml
+++ b/.github/workflows/_build-z3-wasm.yml
@@ -1,23 +1,14 @@
-name: Build Z3 Wasm (Reusable)
+name: Build Z3 Wasm
 
 on:
-  workflow_call:
-    inputs:
-      z3-version:
-        description: 'Z3 version to compile'
-        type: string
-        default: '4.16.0'
-    outputs:
-      artifact-name:
-        description: 'Name of the z3-wasm artifact'
-        value: 'z3-wasm-${{ inputs.z3-version }}'
+  workflow_dispatch:
 
 env:
-  CARGO_TERM_COLOR: always
+  Z3_VERSION: "4.16.0"
 
 jobs:
-  build-z3-wasm:
-    name: Build Z3 ${{ inputs.z3-version }} for wasm
+  build:
+    name: Build Z3 ${{ env.Z3_VERSION }} (wasm)
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -25,16 +16,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: Z3Prover/z3
-          ref: z3-${{ inputs.z3-version }}
+          ref: z3-${{ env.Z3_VERSION }}
           path: z3-src
 
       - name: Setup Emscripten
         uses: mymindstorm/setup-emsdk@v14
         with:
           version: latest
-
-      - name: Verify emsdk
-        run: emcc --version
 
       - name: Configure Z3 with Emscripten
         run: |
@@ -52,29 +40,19 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release
 
       - name: Build Z3
-        run: |
-          cd z3-build
-          ninja z3
-          echo "=== Build artifacts ==="
-          ls -la lib/libz3.a || ls -la libz3.a || find . -name "libz3.a"
+        run: cd z3-build && ninja
 
       - name: Prepare artifact
         run: |
           mkdir -p dist/lib dist/include
-          # 尝试多个可能的路径
           cp z3-build/lib/libz3.a dist/lib/ 2>/dev/null || \
-            cp z3-build/libz3.a dist/lib/ 2>/dev/null || \
             find z3-build -name "libz3.a" -exec cp {} dist/lib/ \;
-          # 复制头文件
           cp z3-src/src/api/z3.h dist/include/
           cp z3-src/src/api/z3_api.h dist/include/ 2>/dev/null || true
-          cp z3-src/src/api/z3_ast_containers.h dist/include/ 2>/dev/null || true
-          echo "=== dist contents ==="
-          ls -la dist/lib/ dist/include/
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: z3-wasm-${{ inputs.z3-version }}
+          name: z3-wasm-${{ env.Z3_VERSION }}
           path: dist/
           retention-days: 90

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -10,7 +10,7 @@ jobs:
     name: Build Wasm
     uses: ./.github/workflows/_build-wasm.yml
     with:
-      artifact-name: wasm-playground
+      artifact-name: wasm-playground-wasm
       retention-days: 7
 
   build-docs:
@@ -27,8 +27,13 @@ jobs:
       - name: Download wasm artifact
         uses: actions/download-artifact@v4
         with:
-          name: wasm-playground
-          path: docs/src/.vitepress/public/wasm
+          name: wasm-playground-wasm
+          path: wasm-temp
+
+      - name: Unpack wasm
+        run: |
+          mkdir -p docs/src/.vitepress/public/wasm
+          unzip -o wasm-temp/yaoxiang-wasm.zip -d docs/src/.vitepress/public/wasm
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,6 +16,13 @@ jobs:
       artifact-prefix: yaoxiang-nightly
       retention-days: 14
 
+  build-wasm:
+    name: Build Wasm
+    uses: ./.github/workflows/_build-wasm.yml
+    with:
+      artifact-name: yaoxiang-nightly-wasm
+      retention-days: 14
+
   security:
     name: Security Audit
     runs-on: ubuntu-latest
@@ -107,3 +114,52 @@ jobs:
           name: coverage-report
           path: target/llvm-cov/html/
           retention-days: 30
+
+  publish:
+    name: Publish Nightly Pre-release
+    needs: [build, build-wasm]
+    if: always() && !cancelled()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get short SHA
+        id: sha
+        run: echo "short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Delete old nightly tag
+        continue-on-error: true
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -d nightly || true
+          git push origin --delete nightly || true
+
+      - name: Create nightly tag
+        run: |
+          git tag nightly
+          git push origin nightly
+
+      - name: Download all artifacts
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          path: release-artifacts
+
+      - name: Create GitHub Pre-release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: nightly
+          name: "Nightly Pre-release"
+          body: |
+            > ⚠️ **这是自动构建的 nightly 版本，仅供测试使用，可能不稳定。**
+
+            Automated nightly build from commit ${{ steps.sha.outputs.short }}
+          prerelease: true
+          files: |
+            release-artifacts/**/yaoxiang-*
+            release-artifacts/**/YaoXiang-Setup-*.exe
+          fail_on_unmatched_files: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,15 @@ jobs:
       artifact-prefix: yaoxiang
       retention-days: 30
 
+  build-wasm:
+    name: Build Wasm
+    needs: check-version
+    if: needs.check-version.outputs.should-release == 'true'
+    uses: ./.github/workflows/_build-wasm.yml
+    with:
+      artifact-name: yaoxiang-wasm
+      retention-days: 30
+
   security:
     name: Security Audit
     needs: check-version
@@ -115,7 +124,7 @@ jobs:
 
   release:
     name: Publish Release
-    needs: [check-version, build, security, test]
+    needs: [check-version, build, build-wasm, security, test]
     if: always() && needs.check-version.outputs.should-release == 'true' && !cancelled() && needs.security.result == 'success' && needs.test.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
## 变更

### 架构
- `_build-z3-wasm.yml` → 独立 workflow_dispatch，产出 Z3 wasm artifact（90天）
- `_build-wasm.yml` → 独立 reusable，跨 run 下载 Z3 → 构建 wasm → zip
- `_build-platforms.yml` → 纯 native 平台构建（删除 z3-wasm 和 wasm job）

### 调用方
| 文件 | 调用 | 说明 |
|------|------|------|
| `release.yml` | parallel(build-platforms, build-wasm) | 两个 path 并行 |
| `nightly.yml` | parallel(build-platforms, build-wasm) | 修复 glob 为 `yaoxiang-*` |
| `docs-deploy.yml` | 只调 build-wasm | ~2min，之前 ~10min |

### 消除浪费
| 场景 | 之前 | 现在 |
|------|------|------|
| docs 推送 | 构建全平台 ~10min | 只构建 wasm ~2min |
| release | 每次构建 Z3 wasm | 复用 artifact |
