### PR TITLE
:bug: fix(ci): _build-z3-wasm job name 不能用 env 上下文

### DIFF
--- a/.github/workflows/_build-z3-wasm.yml
+++ b/.github/workflows/_build-z3-wasm.yml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   build:
-    name: Build Z3 ${{ env.Z3_VERSION }} (wasm)
+    name: Build Z3 4.16.0 (wasm)
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
修复 `${{ env.Z3_VERSION }}` 在 job name 中无法解析的 bug。