### PR TITLE
:bug: fix(build): 修复 release workflow 两个上游 bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > AI辅助的编译器开发探索。
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/Version-v0.7.8-blue.svg)]()
+[![Version](https://img.shields.io/badge/Version-v0.7.10-blue.svg)]()
 
 > 🌐 **Language** | [English](docs/gh/README.en.md)
 >

--- a/docs/gh/README.en.md
+++ b/docs/gh/README.en.md
@@ -3,7 +3,7 @@
 > AI-assisted compiler development exploration.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/Version-v0.7.8-blue.svg)]()
+[![Version](https://img.shields.io/badge/Version-v0.7.10-blue.svg)]()
 
 > 🌐 **Language** | [中文](../../README.md)
 >

--- a/scripts/build/setup.iss
+++ b/scripts/build/setup.iss
@@ -8,7 +8,7 @@
 
 [Setup]
 ; Application identity
-AppId={{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
+AppId={{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}}
 AppName={#MyAppName}
 AppVersion={#MyAppVersion}
 AppVerName={#MyAppName} {#MyAppVersion}

--- a/scripts/hooks/sync-version-badge.py
+++ b/scripts/hooks/sync-version-badge.py
@@ -8,7 +8,7 @@ Runs whenever Cargo.toml or the README files change.
 import re
 from pathlib import Path
 
-REPO = Path(__file__).resolve().parent.parent
+REPO = Path(__file__).resolve().parent.parent.parent
 
 CARGO_TOML = REPO / "Cargo.toml"
 README_FILES = [
@@ -20,7 +20,7 @@ README_FILES = [
 BADGE_RE = re.compile(
     r'(\[!\[Version\]\(https://img\.shields\.io/badge/Version-)'
     r'v[^)]+'
-    r'(-blue\.svg\]\(\))'
+    r'(-blue\.svg\)\]\(\))'
 )
 
 


### PR DESCRIPTION
## 背景

v0.7.10 release workflow (`#204`) 在 main 上触发时，`Publish Release` job 失败，v0.7.10 tag 和 GitHub Release 都没创建。

## 失败原因

release workflow 撞上 **3 个上游 bug**（其中 2 个直接导致 release 失败，第 3 个导致 README badge 永远不更新）：

### 1. `scripts/build/setup.iss` AppId 缺一个 `}` (line 11)
```diff
-AppId={{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
+AppId={{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}}
```
导致 Inno Setup 解析失败 → **Windows Installer build 失败** → Publish Release 被 dependencies 阻断。

### 2. `scripts/hooks/sync-version-badge.py` REPO 路径少一层
```python
-REPO = Path(__file__).resolve().parent.parent
+REPO = Path(__file__).resolve().parent.parent.parent
```
脚本试图读 `scripts/Cargo.toml`，但实际位置是根 `Cargo.toml` → **FileNotFoundError** → Sync version badge step 失败。

### 3. `scripts/hooks/sync-version-badge.py` BADGE_RE regex 少一个 `\)`
```python
-    r'(-blue\.svg\]\(\))'
+    r'(-blue\.svg\)\]\(\))'
```
导致 regex 永远不匹配 README badge —— **这就是 README badge 一直停在 `v0.7.8` 的根因**（v0.7.9 release 时这个 bug 就存在但没被察觉，因为 sync 失败时脚本仍然 exit 0）。

## 验证

- 本地跑 `python scripts/hooks/sync-version-badge.py`，README.md 和 docs/gh/README.en.md 的 badge 都成功从 `v0.7.8` 同步到 `v0.7.10`
- setup.iss AppId 修正后符合 Inno Setup `{{GUID}}` 规范

## 修复后预期

合并到 main 后，release workflow 会自动重跑（因为 v0.7.10 tag 还不存在），完成：
- Windows Installer build
- Sync version badge（已经手动同步了，CI 跑会发现 README 没变化，no-op）
- Create tag v0.7.10
- Create GitHub Release

Refs: #204