### PR TITLE
:bug: fix(build): setup.iss Source 路径多走一层 ..

### DIFF
--- a/scripts/build/setup.iss
+++ b/scripts/build/setup.iss
@@ -55,7 +55,7 @@ Name: "addtopath"; Description: "Add to system PATH"; GroupDescription: "Other o
 
 [Files]
 ; Main executable
-Source: "..\target\release\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
+Source: "..\..\target\release\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
 
 [Icons]
 Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"


### PR DESCRIPTION
## 背景

PR #217 修复了 3 个上游 bug（AppId、REPO 路径、regex），但 release workflow 重跑时 **Windows Installer 仍然失败**：

```
Error on line 58 in scripts/build/setup.iss:
Source file "..\target\release\yaoxiang.exe" does not exist.
```

## 根因

Inno Setup 解析 Source 相对路径时以 .iss 文件所在目录（`scripts/build/`）为基准：
- 原路径 `..\target\release\yaoxiang.exe` → 实际指向 `scripts/target/release/yaoxiang.exe` ❌
- cargo build 把 yaoxiang.exe 放到仓库根 `target/release/yaoxiang.exe`
- 需要 `..\..\target\release\yaoxiang.exe` 才能从 `scripts/build/` 上两级到仓库根

## 修复

```diff
-Source: "..\target\release\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
+Source: "..\..\target\release\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
```

## 影响

合并到 main 后，release workflow 重跑时 Windows Installer job 应该成功，v0.7.10 release pipeline 终于能跑通。

Refs: #204, #217