### PR TITLE
:bug: fix(release): body 来源改用 CHANGELOG.md

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,13 @@ jobs:
             echo "Tag $TAG not found, will release"
             echo "should_release=true" >> $GITHUB_OUTPUT
           fi
+      - name: Delete existing tag (if any)
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          TAG="v${{ steps.version.outputs.value }}"
+          git tag -d "$TAG" 2>/dev/null || true
+          git push origin --delete "$TAG" 2>/dev/null || true
+          echo "Tag cleanup complete (was either absent or deleted)"
 
   build:
     name: Build Platforms
@@ -166,7 +173,7 @@ jobs:
         with:
           tag_name: v${{ needs.check-version.outputs.version }}
           name: v${{ needs.check-version.outputs.version }}
-          body: ${{ github.event.head_commit.message }}
+          body_path: CHANGELOG.md
           files: |
             release-artifacts/**/yaoxiang-*
             release-artifacts/**/YaoXiang-Setup-*.exe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,178 +1,244 @@
 # Changelog
 
-## :bookmark: V0.7.9: Never 内建类型与类型系统深化
+## :bookmark: V0.7.10: 类型空间收敛与单态化清理
 
-> 发布日期: 2026-07-21
+> 发布日期: 2026-07-25
 
 ### 📦 版本信息
 
-| 项目     | 值                |
-| -------- | ----------------- |
-| 发布日期 | 2026-07-21        |
-| 版本变更 | `0.7.8` → `0.7.9` |
-| 提交数   | 56 个 commit      |
+| 项目     | 值                       |
+| -------- | ------------------------ |
+| 发布日期 | 2026-07-25               |
+| 版本变更 | `0.7.9` → `0.7.10`       |
+| 提交数   | 71 个 commit（无 merge） |
 
 ### 📋 本次更新概要
 
-本次发版是类型系统的一次重大深化。Never 内建类型正式引入（爆炸原则、子类型判定、trait 实现），宇宙分层 predicative 弱检查和类型级递归终止性检查为泛型系统提供了更坚实的理论基础。流敏感假设集替代旧栈式 AssumptionStack 实现了更精确的 Γ 推导，const 泛型约束新增 `<` 和 `<=` 运算符支持。同时 std.assert 统一注册机制、TextMate grammar 重写和 formatter 泛型签名重建等改进进一步提升了开发体验。
+本次发版聚焦类型系统内部的清理与收敛。typecheck 引入**语义 base 解析原语**（`resolve_base_kind`），方法注册从 `StructType.methods` 双存储收敛到 `method_bindings` 单一源；monomorphize **删除死代码子系统**并引入新扫描阶段（`feat(monomorphize): 收集和扫描泛型类型引用`），配合 E2E 测试覆盖。typecheck 端消除 **8 处静默兜底**（`fix(typecheck): 消除 8 处静默兜底`），修复 Float→Int 隐式转换拦截、curried 泛型 return 块等关键类型检查漏洞，CI 重新回到绿色。测试规范升级 —— `.yx` 文件统一从 `io.println` 切换到 `assert.assert` 断言（`refactor(test): .yx 测试文件从 io.println 切换到 assert.assert`），文档站多语言同步更新。
 
 ### ✨ 新功能
 
-#### Never 内建类型
+#### 语义 base 解析与类型空间收敛
 
-正式引入 Never 底类型，完整实现爆炸原则（ex falso quodlibet）、子类型判定（Never 是任何类型的子类型）和 trait impl 注册。Never 在所有解析点正确解析，支持 const_eval size 计算，与 Void 类型形成了完整的底层类型体系。
+typecheck 引入 `resolve_base_kind` 原语，方法解析和鸭子类型约束统一查 `StructType.methods` 类型空间。配套重构撤销了 `StructType.methods` 双存储分裂、让方法解析优先走类型空间、把登记侧按 base 语义分流。整套改动是 typecheck 内部架构统一的关键一步，对用户 API 无破坏。
 
-- 新增 MonoType::Never 变体及穷举匹配 arm
-- 注册为类型检查环境的内建类型
-- 所有解析点正确解析 Never/never → MonoType::Never
-- 实现爆炸原则、trait impls、const_eval size 支持
-- 修复 trait_key、structurally_equal、unify 三处核心路径
+- `feat(typecheck): 加 resolve_base_kind 语义 base 解析原语`
+- `feat(typecheck): 语义 base 解析原语 + 类型空间落 StructType.methods`
+- `feat(typecheck): 登记侧按 base 语义分流类型空间`
+- `refactor(typecheck): 方法解析优先查 StructType.methods 类型空间`
+- `refactor(typecheck): 鸭子类型约束查 StructType.methods`
+- `refactor(typecheck): 撤销 StructType.methods 双存储，方法回归 method_bindings 单一源`
 
-#### IsTrue 类型族桥接
+#### monomorphize 收集与扫描阶段
 
-实现 IsTrue 类型族，将 `true` 映射到 `Void`、`false` 映射到 `Never`，为编译期条件判定提供了统一的类型级表达。
+monomorphize 引入收集和扫描泛型类型引用的新阶段，为后续单态化接入做准备。配套 4 个测试提交（单元测试 + E2E + 补充覆盖 + 合规修复）保证新阶段的可靠性。
 
-#### const 泛型约束运算符
+- `feat(monomorphize): 收集和扫描泛型类型引用`
+- `test(monomorphize): 泛型类型单态化单元测试`
+- `test(monomorphize): 泛型类型端到端测试`
+- `test(monomorphize): 补充泛型类型单态化测试覆盖`
+- `test(monomorphize): 泛型类型测试合规修复`
 
-parser 全面支持 const 泛型约束中的 `<` 和 `<=` 比较运算符，新增 E1062/W1063 错误码覆盖约束检查。
+#### 值空间字段赋值 schema 校验
 
-#### 流敏感假设集 Γ
+typecheck 在值空间字段赋值处增加 schema 校验，杜绝运行时才能发现的字段拼写错误。
 
-流敏感假设集 Γ 配合 kill set 完全替换了旧的栈式 AssumptionStack，实现了更精确的类型推导路径追踪。
+- `feat(typecheck): 值空间字段赋值 schema 校验`
 
-#### 宇宙分层与类型级递归
+#### const 泛型扩展
 
-- 宇宙分层 predicative 弱检查 — Typeₙ <: Typeₘ 当 n ≤ m
-- 类型级递归检测 + 结构递归终止性检查（AssociatedTypeDef::Recursive）
-- dispatch 分派管道接线 — CompileTime/Runtime + mut kill
+parser 支持 const 泛型中的算术运算符，typecheck 实现函数级 const 泛型（RFC-011），为编译期常量计算打开新路径。
 
-#### TextMate grammar 重构
+- `feat(parser): parse_type_annotation ConstExpr 支持算术运算符`
+- `feat(typecheck): 实现函数级 const 泛型 (RFC-011)`
 
-lexer 层重构 TextMate grammar，完整支持 fstrings 和全部类型的高亮标记，配合新的构建流水线实现自动同步。
+#### 类型构造器精化
 
-#### std.assert 统一注册
+typecheck 精化类型构造器，统一 `{}` 语义和 proof 函数，消解类型构造器多种用法引起的歧义。
 
-StdModule trait 扩展 type_families 方法，std.assert 模块通过统一注册机制接入，dispatch 分派管道支持 CompileTime/Runtime 双路径。
+- `feat(typecheck): 精化类型构造器——{}统一语义与 proof 函数`
 
 ### 🐛 Bug 修复
 
-#### parser 值参数处理
+#### 静默兜底消除
 
-修复值参数过滤统一大小写规则导致的 Const 泛型错位问题，修正 merged 状态下的错位并移除了临时的清洗补丁代码。
+`fix(typecheck): 消除 8 处静默兜底` 是本版最重要的修复之一 —— checker、ir_gen、translator、debug、normalizer 五条核心路径上 8 处悄悄把错误吞掉的代码被替换为显式错误信号，让开发期问题暴露更早。
 
-#### formatter ConstExpr 还原
+- `fix(typecheck): 消除 8 处静默兜底`
+- `fix(typecheck): 修复 doc_lazy_continuation 告警`
+- `fix(middle): 修复局部变量持函数值调用失败`
 
-修复 ConstExpr 还原与类型体保序格式化问题，确保格式化输出与解析输入一致。
+#### 类型检查漏洞
 
-#### Never 子类型修复
+修复多种类型检查漏洞：Float→Int 隐式转换拦截（拒绝精度丢失）、curried 泛型 return 块形式类型检查、Never 函数循环放行与 const 泛型 curry 格式化、From<ast::Type> 内建类型 bypass 拦截、resolve-then-check 替换盲跳过、void 字面量在表达式位置解析失败、纯函数声明。
 
-修复 Never 在 trait_key、structurally_equal、unify 三条核心路径的错误 — 分别补全 MonoType::Never arm、对称递归判定和统一分支。
+- `fix(typecheck): 函数调用参数 Float→Int 隐式转换拦截`
+- `fix(typecheck): curried 泛型函数 return 块形式类型检查`
+- `fix(typecheck): Never 函数循环放行 + const 泛型 curry 格式化`
+- `fix: resolve builtin type names in From<ast::Type> to prevent TypeRef bypass`
+- `fix: replace blind TypeRef skip with resolve-then-check in function call args`
+- `fix(parser): void 字面量在表达式位置解析失败`
+- `fix(parser): 纯函数声明 (#168)`
 
-#### yx_runner 兼容性
+#### CI / 构建 / 文档
 
-将编译错误测试移至 06 目录，运行时失败标记 skip，确保 yx_runner 兼容运行。
+- `fix(ci): 修复 8 个 clippy 错误使 CI 回归绿色`
+- `fix(meta): clippy 冗余模式匹配`
+- `fix(meta): run 命令编译失败时显式 exit(1) 确保非零退出码`
+- `fix(docs): 删除 vitepress 配置中多余的右括号`
 
 ### ♻️ 重构优化
 
-#### 类型体与约束分离
+#### monomorphize 死代码清理
 
-Type::Struct 改为有序 TypeBodyItem，约束字段与普通字段分离 — Assert 走 constraints 路径不混入 fields。ConstExpr 统一到 const_data，StructType.constraints 和 Assert 硬编码删除。
+删除 monomorphize 死掉的泛型类型单态化子系统 —— 旧实现未被任何代码路径调用、保留只会增加维护负担。
 
-#### 泛型实例化路径统一
+- `refactor(monomorphize): 删除死掉的泛型类型单态化子系统`
 
-统一泛型实例化路径，Layer 2 约束检查接管所有分支。消除 clippy match 简化警告，StdModule trait 扩展 type_families。
+#### 赋值统一
 
-#### Binding 签名参数
+typecheck 引入 `Assign` 统一替代 `Var/Binding/ExternalBindingStmt` 三种赋值节点，简化赋值路径，配套完成"三个凑合修复重构"（消除状态标志与重复逻辑）。
 
-Binding 的签名参数统一存储到 signature_params，消除了重复构造和双路径问题。
+- `refactor(typecheck): 赋值统一——Assign 替代 Var/Binding/ExternalBindingStmt`
+- `refactor(typecheck): 三个凑合修复重构——消除状态标志与重复逻辑`
+
+#### TypeRef 解析委托
+
+类型解析统一委托给 `from_builtin_name`，移除多处硬编码 `TypeRef(Bool/Void)`，让内建类型解析走单一通路。
+
+- `refactor: remove redundant inline TypeRef resolution in check_var_stmt`
+- `refactor: delegate resolve_builtin_type_ref to from_builtin_name`
+- `refactor: delegate resolve_type_ref_type builtins to from_builtin_name`
+- `refactor: delegate resolve_type_refs leaf to from_builtin_name`
+- `refactor: replace hardcoded TypeRef(Bool/Void) with concrete types`
+
+#### FunctionBody 枚举统一
+
+middle 层将 `FunctionBody` 枚举统一为类型定义和函数体共享的 IR 节点，让 codegen 不再分两条路径走。
+
+- `refactor(middle): FunctionBody 枚举统一类型定义和函数体`
+- `refactor(middle): 构造器识别查表化并清理死代码`
+
+#### parser 清理
+
+- `refactor(parser): 删除死代码 extract_generic_params`
+- `refactor(parser): TypeDefinition 变体消除类型定义形状猜测`
+
+#### 性能与代码风格
+
+- `perf(list): pop/remove_at use heap.get_mut() instead of clone+write (#192)` — 列表原位修改不再 clone+write
+- `style(formatter): cargo fmt——assert_eq! 参数分行`
+- `style(typecheck): flatten nested match in function call resolver`
 
 ### ✅ 测试改进
 
-- formatter 泛型类型定义 round-trip 集成用例
-- parser const 约束 < 与 <= E2E 用例
-- typecheck gamma_assume 测试补规范引用与 AAA 分段
-- assert 运行时通过和 panic 的 E2E 测试
-- 测试合规修复 — inline tests 拆出 + AAA + 断言消息 + 规范头
-- IsTrue 测试合规修复
-- Never 新增子类型/解析/条件判定三组测试
+#### .yx 测试文件 assert 化
+
+按 `TEST_STANDARDS` 文档规范，`.yx` 测试文件从 `io.println` 切换到 `assert.assert` 断言。这是子代理扫尾工作的成果，3 个遗漏文件被修复。
+
+- `refactor(test): .yx 测试文件从 io.println 切换到 assert.assert`
+- `refactor(test): 修复子代理遗漏的 3 个 .yx 文件 + 更新 TEST_STANDARDS 文档`
+
+#### 其他测试
+
+- `test(test): 新增 curried 函数赋值后调用集成测试`
+- `test(formatter): 测试合规——加 AAA 分段注释符合规范 §4.1`
+- `test(parser): 修复测试规范违规——断言消息+命名+规范引用`
+- `test: add failing tests for Float→Int function call argument`
 
 ### 📝 文档
 
-- 同步文档至统一声明语法
-- 同步英文翻译并清理项目结构章节
-- 重写模块语义 RFC-029
-- RFC-011 类型体代码块与效应种子已实现
-- RFC-030 assert 断言机制移入已接受并标注实现
-- 标注 assert/Assert 统一方案 6 Phase 已实现 — #157-#162 已关闭
-- 升级 Star History 图表支持暗黑模式
-- 自动翻译文档同步
+- `docs(docs): 更新英文文档站内容与 i18n 缓存`
+- `docs(docs): 同步日文和俄文文档站 i18n 翻译`
+- `docs(docs): 清理过时文档并修复多处引用错误`
+- `docs(meta): auto-dev-night 修复报告（撤出 #181，留待 PR #186）`
+- `docs: auto-translate documentation`
 
 ### 🔧 其他变更
 
-- TextMate grammar 同步构建流水线
-- 清理废弃的教程示例与更新 formatter 设计文档
-- Bump production-dependencies (regex, toml, clap, tokio, lsp-server)
-- 清理 Python 测试脚本中未使用的导入和格式问题
-- 添加版本号 badge 自动同步 hook
-- i18n 自动翻译 locale 文件
+#### 依赖与 CI
+
+- `chore(deps): Bump the production-dependencies group with 6 updates`
+- `chore(build): 更新 production-dependencies 组 6 个依赖`
+- `chore(ci): 所有 dependabot 更新指向 dev 分支`
+- `ci(ci): 将版本徽章同步从本地钩子迁移至 CI 流程`
+- `ci(workflows): 升级 GitHub Actions 版本至 Node.js 24`
+- `chore(docs): 更新文档站构建依赖与站点配置`
+- `refactor(build): 重组 scripts 目录结构`
+- dependabot 自动 bump: `esbuild` / `vite`（scripts/i18n）、`brace-expansion` 2.0.2→2.1.2、`minimatch` 5.1.7→5.1.9
+
+#### 文档清理
+
+- `chore(docs): 移除过时的计划文档目录`
 
 ### 📝 提交记录
 
-|   Hash    | 描述                                                                  |
-| :-------: | --------------------------------------------------------------------- |
-| `4b886b6` | feat(types): Never 内建类型 — add MonoType::Never variant with exhaustiveness arms |
-| `490f523` | feat(types): Never 内建类型 — register as builtin type in typecheck environment |
-| `ef6647c` | feat(types): Never 内建类型 — resolve Never/never to MonoType::Never at all parse points |
-| `c502dd9` | feat(types): Never 内建类型 — add explosion principle, trait impls, and const_eval size support |
-| `552c47f` | fix(types): Never — trait_key structural_equal unify 三处修复 |
-| `c74fbc1` | test(types): Never — 新增子类型/解析/条件判定三组测试 |
-| `db25f6c` | feat(types): 实现 IsTrue 类型族桥接 — true→Void false→Never |
-| `a5c1554` | test(types): IsTrue — 测试合规修复 |
-| `5e0eace` | feat(proof): 流敏感假设集 Γ + kill set — 替换纯栈 AssumptionStack |
-| `c820535` | feat(typecheck): dispatch 分派管道接线 — CompileTime/Runtime + mut kill |
-| `5a7e576` | feat(types): 宇宙分层 predicative 弱检查 — Typeₙ<:Typeₘ 当 n≤m |
-| `90e6772` | feat(types): 类型级递归 + 结构递归终止性 — AssociatedTypeDef::Recursive |
-| `56828f6` | feat(typecheck): 新增 E1062/W1063 错误码 — const 泛型约束 |
-| `3b233b0` | refactor(typecheck): 统一泛型实例化路径 — Layer 2 约束检查 |
-| `d340240` | feat(parser): 支持 const 泛型约束中的 < 和 <= 比较运算符 |
-| `c6757f1` | test(parser): const 约束 < 与 <= E2E 用例 |
-| `24e5f17` | refactor(typecheck): Type::Struct 分离约束字段 — Assert 走 constraints 不混入 fields |
-| `6af2de1` | refactor(parser): Type::Struct 改为有序 TypeBodyItem |
-| `63a8268` | refactor(types): 删 StructType.constraints 与 Assert 硬编码 |
-| `f39daf4` | refactor(types): 统一 ConstExpr 到 const_data |
-| `4ba6c52` | feat(typecheck): 顺序处理类型体收集 const 约束 |
-| `b304574` | feat(typecheck): 效应种子 GammaAssume 接入 Γ |
-| `24ff47f` | test(typecheck): gamma_assume 测试补规范引用与 AAA 分段 |
-| `c96e5f0` | test(typecheck): 测试合规修复 — inline tests 拆出 + AAA + 断言消息 + 规范头 |
-| `210e603` | docs(rfc): RFC-011 类型体代码块与效应种子已实现 |
-| `1caa3ca` | refactor(std): StdModule trait 扩展 type_families + std.assert 模块 |
-| `6a6985a` | refactor(typecheck): 清除硬编码 + 修复空 dep_env — 走 std.assert 正路 |
-| `09c4f78` | test(test): assert 运行时通过和 panic 的 E2E 测试 |
-| `616b265` | docs(design): RFC-030 标注 std.assert 统一注册已实现 — #169 已关闭 |
-| `08f4a38` | docs(docs): 将 RFC-030 assert 断言机制移入已接受 |
-| `abe8a8e` | docs(rfc): 标注 assert/Assert 统一方案 6 Phase 已实现 — #157-#162 已关闭 |
-| `c9ff2f5` | fix(test): yx_runner 兼容 — 编译错误测试移至 06 + 运行时失败标记 skip |
-| `089a1b8` | refactor(parser): Binding 签名参数统一存储 signature_params |
-| `457b54b` | feat(formatter): 函数签名统一带名输出并删除双补丁函数 |
-| `deb344f` | feat(formatter): 泛型类型定义重建 RFC-010 函数式签名 |
-| `c04990b` | test(formatter): 泛型类型定义 round-trip 集成用例 |
-| `75b588b` | fix(formatter): ConstExpr 还原与类型体保序格式化 |
-| `123b66f` | fix(parser): 值参数过滤统一大小写规则修复 Const 泛型错位 |
-| `8e6708d` | fix(parser): 修正值参数 merged 错位并移除清洗补丁 |
-| `9e38255` | feat(lexer): 重构 TextMate grammar 支持 fstrings 和完整类型高亮 |
-| `2fde7c1` | build(docs): 新增 TextMate grammar 同步构建流水线 |
-| `6411127` | refactor(typecheck): 消除 clippy match 简化警告 |
-| `9cd4990` | chore(docs): 清理废弃的教程示例与更新 formatter 设计文档 |
-| `0b0e5bc` | docs(docs): 同步文档至统一声明语法 |
-| `4f5e302` | docs: auto-translate documentation |
-| `c7b5613` | docs: auto-translate documentation |
-| `5b33ef6` | docs: auto-translate documentation |
-| `0bab085` | docs: auto-translate documentation |
-| `a3969dc` | docs: auto-translate documentation |
-| `261126a` | chore(deps): Bump production-dependencies |
-| `68d9ef2` | docs(design): 重写模块语义 RFC-029 |
-| `2454ceb` | docs(docs): 同步英文翻译并清理项目结构章节 |
-| `3795a00` | style(test): 清理 Python 测试脚本中未使用的导入和格式问题 |
-| `7d23914` | chore(build): 添加版本号 badge 自动同步 hook |
-| `3fe5b82` | docs(docs): 升级 Star History 图表支持暗黑模式 |
-| `3afa123` | i18n: auto-translate locale files |
+|   Hash    | 描述                                                                                       |
+| :-------: | ------------------------------------------------------------------------------------------ |
+| `7bdfd3b8` | test(monomorphize): 补充泛型类型单态化测试覆盖                                              |
+| `198c1889` | test(monomorphize): 泛型类型测试合规修复                                                    |
+| `e56adae8` | refactor(test): 修复子代理遗漏的 3 个 .yx 文件 + 更新 TEST_STANDARDS 文档                  |
+| `babd1952` | refactor(test): .yx 测试文件从 io.println 切换到 assert.assert                              |
+| `a448fb16` | test(monomorphize): 泛型类型端到端测试                                                      |
+| `3098dd50` | test(monomorphize): 泛型类型单态化单元测试                                                  |
+| `9cc66eed` | feat(monomorphize): 收集和扫描泛型类型引用                                                  |
+| `fa137789` | refactor(middle): FunctionBody 枚举统一类型定义和函数体                                     |
+| `046ad9c6` | chore(build): 更新 production-dependencies 组 6 个依赖                                      |
+| `465370d3` | chore(deps): Bump the production-dependencies group with 6 updates                          |
+| `3ec98aa5` | fix(typecheck): 修复 doc_lazy_continuation 告警                                             |
+| `30f7ae63` | fix(typecheck): 消除 8 处静默兜底                                                          |
+| `c6a9d95b` | test(test): 新增 curried 函数赋值后调用集成测试                                            |
+| `afee9581` | fix(middle): 修复局部变量持函数值调用失败                                                  |
+| `59d82cb8` | feat(parser): parse_type_annotation ConstExpr 支持算术运算符                                |
+| `fed7b412` | refactor(monomorphize): 删除死掉的泛型类型单态化子系统                                      |
+| `d8b62889` | refactor(typecheck): 撤销 StructType.methods 双存储                                         |
+| `a6a8937b` | refactor(typecheck): 鸭子类型约束查 StructType.methods                                      |
+| `70e2de20` | feat(typecheck): 值空间字段赋值 schema 校验                                                 |
+| `c11eefc6` | refactor(typecheck): 方法解析优先查 StructType.methods 类型空间                             |
+| `fbc61752` | feat(typecheck): 登记侧按 base 语义分流类型空间                                             |
+| `4f2ed101` | feat(typecheck): 语义 base 解析原语 + 类型空间落 StructType.methods                         |
+| `75ce5de2` | refactor(parser): 删除死代码 extract_generic_params                                         |
+| `d0a37e4e` | feat(typecheck): 加 resolve_base_kind 语义 base 解析原语                                   |
+| `7b103571` | build(deps): bump esbuild and vite in /scripts/i18n                                         |
+| `f7f1cfe4` | build(deps): bump brace-expansion from 2.0.2 to 2.1.2                                       |
+| `d159c1c3` | build(deps): bump minimatch from 5.1.7 to 5.1.9                                             |
+| `9879a239` | chore(ci): 所有 dependabot 更新指向 dev 分支                                                |
+| `372797ec` | refactor(build): 重组 scripts 目录结构                                                      |
+| `82d9b18f` | docs(docs): 更新英文文档站内容与 i18n 缓存                                                  |
+| `02e77fde` | docs(docs): 同步日文和俄文文档站 i18n 翻译                                                  |
+| `6e58f45d` | chore(docs): 移除过时的计划文档目录                                                          |
+| `348e7902` | chore(docs): 更新文档站构建依赖与站点配置                                                  |
+| `b22231d2` | ci(ci): 将版本徽章同步从本地钩子迁移至 CI 流程                                              |
+| `893f2b64` | fix(docs): 删除 vitepress 配置中多余的右括号                                                |
+| `14f8de90` | fix(ci): 修复 8 个 clippy 错误使 CI 回归绿色                                                |
+| `5689b712` | style(formatter): cargo fmt——assert_eq! 参数分行                                            |
+| `e4b5914e` | style(typecheck): flatten nested match in function call resolver                            |
+| `04d3d511` | perf(list): pop/remove_at use heap.get_mut() instead of clone+write                         |
+| `1a8bd3f3` | refactor: remove redundant inline TypeRef resolution in check_var_stmt                      |
+| `c96d4194` | refactor: delegate resolve_builtin_type_ref to from_builtin_name                            |
+| `d0a3f11b` | refactor: delegate resolve_type_ref_type builtins to from_builtin_name                      |
+| `f8548d0d` | refactor: delegate resolve_type_refs leaf to from_builtin_name                              |
+| `3817d580` | refactor: replace hardcoded TypeRef(Bool/Void) with concrete types                          |
+| `f32a8634` | test(formatter): 测试合规——加 AAA 分段注释符合规范 §4.1                                    |
+| `ef357129` | fix: replace blind TypeRef skip with resolve-then-check in function call args               |
+| `89dc0659` | fix: resolve builtin type names in From<ast::Type> to prevent TypeRef bypass                |
+| `6b053589` | test: add failing tests for Float→Int function call argument                                |
+| `6723b505` | refactor(typecheck): 三个凑合修复重构——消除状态标志与重复逻辑                              |
+| `2bc28237` | docs(meta): auto-dev-night 修复报告（撤出 #181，留待 PR #186）                              |
+| `278902c6` | fix(parser): 纯函数声明 (#168)                                                              |
+| `74e1a623` | fix(typecheck): 函数调用参数 Float→Int 隐式转换拦截                                        |
+| `6aa4161f` | fix(typecheck): curried 泛型函数 return 块形式类型检查                                      |
+| `a80f7d01` | fix(typecheck): Never 函数循环放行 + const 泛型 curry 格式化                                |
+| `9bb5b1a4` | feat(typecheck): 精化类型构造器——{}统一语义与 proof 函数                                   |
+| `41b36f65` | test(parser): 修复测试规范违规——断言消息+命名+规范引用                                      |
+| `e901a816` | refactor(typecheck): 赋值统一——Assign 替代 Var/Binding/ExternalBindingStmt                 |
+| `5b57101f` | fix(meta): clippy 冗余模式匹配                                                              |
+| `13d9bcca` | fix(parser): void 字面量在表达式位置解析失败                                                |
+| `2c4075cd` | fix(meta): run 命令编译失败时显式 exit(1) 确保非零退出码                                    |
+| `df6b1f2e` | docs: auto-translate documentation                                                           |
+| `12715cdd` | feat(typecheck): 实现函数级 const 泛型 (RFC-011)                                            |
+| `01420910` | docs(docs): 清理过时文档并修复多处引用错误                                                  |
+| `a4984fa0` | refactor(parser): TypeDefinition 变体消除类型定义形状猜测                                   |
+| `4db5376e` | refactor(middle): 构造器识别查表化并清理死代码                                              |
+| `456734c2` | ci(workflows): 升级 GitHub Actions 版本至 Node.js 24                                        |
+| `1f0015d8` | refactor: FunctionBody 枚举统一 + 泛型类型单态化 + .yx 测试文件 assert 重构（squash merge，Closes #197, #200） |


### PR DESCRIPTION
## 背景

v0.7.10 release body 是 PR #217 的 fix message，**不是** v0.7.10 的 changelog——根因是 release workflow 用 `github.event.head_commit.message` 作为 body，而触发 workflow 的最近 push 是 hotfix PR。

v0.7.9 看起来工作只是运气（main HEAD = version merge commit，message 碰巧含 changelog）。

## 改动

### 1. release.yml: `body_path: CHANGELOG.md`
```yaml
-body: ${{ github.event.head_commit.message }}
+body_path: CHANGELOG.md
```
让 release body 永远 = CHANGELOG.md（最新发版快照），跟 commit message 解耦。

### 2. release.yml: workflow_dispatch 触发时自动清理旧 tag
```yaml
- name: Delete existing tag (if any)
  if: github.event_name == 'workflow_dispatch'
  run: |
    git tag -d "$TAG" 2>/dev/null || true
    git push origin --delete "$TAG" 2>/dev/null || true
```
- push 触发：不动 tag（first-time 不存在，cleanup 跳过）
- workflow_dispatch：删旧 tag，让 build 重新跑
- 让 re-run workflow 能完整重建（v0.7.10 缺 Windows Installer，下次发版前可重跑补齐）

### 3. CHANGELOG.md: 语义改为「最新发版快照」
- 之前：保留 v0.7.9 + v0.7.10 全部历史
- 现在：只保留 v0.7.10
- 历史 changelog 由 GitHub Releases 页面承担

## 影响

- 下次发版（v0.7.11+）的 release body 自动 = CHANGELOG.md，不用手动补救
- workflow_dispatch 可用于"补 Windows Installer"等场景的重跑

Refs: #204
