### PR TITLE
:green_heart: ci(release): 修复发版流程并完成 v0.7.11 发布

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,14 +142,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Sync version badge to README
-        run: |
-          python scripts/hooks/sync-version-badge.py
-          git add README.md docs/gh/README.en.md
-          git diff --cached --quiet || \
-            git commit -m "chore: sync version badge to v${{ needs.check-version.outputs.version }} [skip ci]"
-          git push
-
       - name: Create and push tag
         run: |
           TAG="v${{ needs.check-version.outputs.version }}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,6 +44,13 @@ repos:
         language: system
         pass_filenames: false
 
+      - id: sync-version-badge
+        name: sync version badge to README
+        entry: python scripts/hooks/sync-version-badge.py
+        language: system
+        files: '^(Cargo\.toml|README\.md|docs/gh/README\.en\.md)$'
+        pass_filenames: false
+
       - id: markdownlint
         name: markdownlint docs
         entry: markdownlint "docs/**/*.md" --fix --config docs/.markdownlint.jsonc --ignore-path docs/.markdownlintignore

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > AI辅助的编译器开发探索。
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/Version-v0.7.10-blue.svg)]()
+[![Version](https://img.shields.io/badge/Version-v0.7.11-blue.svg)]()
 
 > 🌐 **Language** | [English](docs/gh/README.en.md)
 >

--- a/docs/gh/README.en.md
+++ b/docs/gh/README.en.md
@@ -3,7 +3,7 @@
 > AI-assisted compiler development exploration.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/Version-v0.7.10-blue.svg)](https://github.com/chenxu233/YaoXiang)
+[![Version](https://img.shields.io/badge/Version-v0.7.11-blue.svg)](https://github.com/chenxu233/YaoXiang)
 
 > 🌐 **Language** | [中文](../../README.md)
 >

--- a/vscode-extension/language-pack/syntaxes/yaoxiang.tmLanguage.json
+++ b/vscode-extension/language-pack/syntaxes/yaoxiang.tmLanguage.json
@@ -33,7 +33,7 @@
       "patterns": [
         {
           "name": "keyword.control.yaoxiang",
-          "match": "\\b(if|elif|else|match|while|for|in|return|break|continue)\\b"
+          "match": "\\b(if|else|match|while|for|in|return|break|continue)\\b"
         },
         {
           "name": "keyword.declaration.yaoxiang",


### PR DESCRIPTION
## 背景

上一个发版 PR (#238) 合并后，Release workflow 在 `Publish Release` 的 **`Sync version badge to README`** 步骤失败：该步骤在 `git config user.name/email` 配置**之前**执行 `git commit`，badge 从 v0.7.10 → v0.7.11 触发 commit 时因缺少 git 身份而失败，导致 **tag `v0.7.11` 与 GitHub Release 未生成**。

## 本 PR 的修复

- **release.yml**：删除 `Sync version badge to README` 步骤（不再由 CI 向 main 推送徽章 commit，即「别塞 main」）。
- **.pre-commit-config.yaml**：新增 `sync-version-badge` 钩子，在 `Cargo.toml` / `README.md` / `docs/gh/README.en.md` 变动时本地同步徽章（版本号 bump 的同一 commit 里自动带上徽章更新）。
- **README.md / README.en.md**：徽章同步至 v0.7.11（英文保留链接 URL）。
- **canonical grammar**：清理残留的 `elif` 关键字（语言已于 `ad8e3dc7` 移除 `elif`，但 grammar 源未同步，导致每次 docs 构建会重新引入）。

## 效果

合并到 main 后，push 事件会重新触发 Release workflow。`check-version` 检测到 Cargo.toml 版本 `0.7.11` 且 `v0.7.11` tag 不存在 → `should-release=true` → 构建并**自动打 tag + 创建 GitHub Release**（使用已修复、无失败步骤的 workflow）。
