### PR TITLE
:bug: fix(util): wasm 构建 E0425（v0.7.12 补发 wasm 包）

### DIFF
--- a/src/util/diagnostic/mod.rs
+++ b/src/util/diagnostic/mod.rs
@@ -199,7 +199,6 @@ fn format_runtime_stack_trace(
 ///
 /// # 返回
 /// 成功返回 `()`，失败返回错误
-#[cfg(feature = "cli")]
 /// RFC-029: 判断文件是否位于一个 yaoxiang 项目内（沿目录向上查找 yaoxiang.toml）。
 fn in_yaoxiang_project(file: &std::path::Path) -> bool {
     let mut dir = file.parent();


### PR DESCRIPTION
## 修复 v0.7.12 发版阻塞：wasm 构建 E0425

**问题**: wasm-pack 构建（`default-features = false`）时，`#[cfg(feature = "cli")]` 把 `in_yaoxiang_project` 定义抹掉，但 `run_file_with_diagnostics` 无条件调用 → `E0425: cannot find function`。导致 v0.7.12 Release 的 Build Wasm job 失败，`yaoxiang-wasm.zip` 缺失。

**修复**: 去掉函数上的 `#[cfg(feature = "cli")]`（函数本身无 cli 依赖，只查路径）。lsp/repl 模块用 `#[cfg(not(target_arch = "wasm32"))]` 保护，不受影响。

**验证**: wasm crate `cargo check --target wasm32-unknown-unknown` 通过；lib 1778 全过；`yaoxiang test` 102/0。

合并后手动补传 `yaoxiang-wasm.zip` 到 v0.7.12 Release。