### PR TITLE
feat(typecheck): RFC-011a 接口机制静态分发端到端（#307 阶段0-2）

### DIFF
--- a/docs/.markdownlintignore
+++ b/docs/.markdownlintignore
@@ -8,3 +8,4 @@ src/ru
 src/archive
 src/design/rfc/deprecated
 src/design/rfc/rejected
+docs/superpowers

--- a/docs/src/reference/error-codes.md
+++ b/docs/src/reference/error-codes.md
@@ -55,6 +55,13 @@ YaoXiang 编译器使用错误码标识不同类型的诊断信息。错误码�
 | E1090  | `Type: Type = Type`                                                            | 不可言说（彩蛋）                     |
 | E1091  | `Generic meta-type self-reference is not allowed: '{decl}'`                    | 无效的泛型元类型                     |
 | E1062  | `Const generic constraint violation: {reason}`                                 | const泛型约束违反                    |
+| E1064  | `Invalid binding position(s) {positions} for function with {total} parameter(s)` | 绑定位置索引无效（RFC-004）          |
+| E1095  | `Unknown interface: '{name}'`                                                  | 未知接口（RFC-011a）                 |
+| E1096  | `Interface '{name}' expects {expected} type argument(s), found {found}`        | 接口实例化实参个数不符               |
+| E1097  | `Interface member '{member}' conflicts with field of type '{type}'`            | 接口成员与字段命名冲突               |
+| E1098  | `Type '{type}' does not implement '{interface}.{method}'`                      | 接口方法未实现                       |
+| E1099  | `Signature mismatch for '{type}.{method}': expected '{expected}', found '{found}'` | 接口方法签名不匹配               |
+| E1100  | `Duplicate implementation of '{type}.{method}' (override is not allowed)`      | 同签名方法重复实现（覆盖禁止）       |
 
 ## E2xxx -- 语义分析
 

--- a/docs/src/reference/language-spec/stdlib.md
+++ b/docs/src/reference/language-spec/stdlib.md
@@ -365,7 +365,9 @@ for i in 0..10..2 {
 > `x in r` 运行时走 `std.range.contains`（界检查 + 步长对齐），证明管道识别为区间命题
 > `x >= r.start && x < r.end && (x - r.start) % r.step == 0`（区间保持区间，不物化）。
 > step=0 字面量编译期拒绝，动态 step=0 运行时错误（未来错误系统落地后升格 Result，#301）。
-> 接口实例化（类型体 `Iterator(Int)` 声明）待 RFC-011a 落地（#307），当前协议面由 std.range 提供。
+> 接口实例化（类型体 `Iterator(Int)` 声明）的类型语法与静态分发已随 RFC-011a 阶段 1-2 落地（#307）：
+> 类型体应用项 `Iterator(Int)` 触发 `Self ↦ Range` 替换展开与完整性检查，通过后生成实现证明。
+> std.range 模块的运行时协议面暂仍由原生方法提供，迁移到接口分发属 #307 阶段 3。
 
 ---
 

--- a/src/frontend/core/parser/ast.rs
+++ b/src/frontend/core/parser/ast.rs
@@ -750,4 +750,35 @@ impl Expr {
             _ => (Vec::new(), Vec::new()),
         }
     }
+
+    /// RFC-004: 从绑定语句 `Type.method = fn[pos]` 的 index 部分提取位置列表。
+    /// 支持单个整数与整数元组；负索引（`-1` 从末尾计数）原样保留，
+    /// 由调用方按被绑函数元数归一化。无法识别时回退 `[0]`（与既有行为一致）。
+    pub fn extract_binding_positions(index: &Expr) -> Vec<i64> {
+        fn one(e: &Expr) -> Option<i64> {
+            match e {
+                Expr::Lit(Literal::Int(n), _) => Some(*n as i64),
+                Expr::UnOp {
+                    op: UnOp::Neg,
+                    expr,
+                    ..
+                } => match expr.as_ref() {
+                    Expr::Lit(Literal::Int(n), _) => Some(-(*n as i64)),
+                    _ => None,
+                },
+                _ => None,
+            }
+        }
+        match index {
+            Expr::Tuple(items, _) => {
+                let parsed: Vec<i64> = items.iter().filter_map(one).collect();
+                if parsed.is_empty() {
+                    vec![0]
+                } else {
+                    parsed
+                }
+            }
+            other => one(other).map(|p| vec![p]).unwrap_or_else(|| vec![0]),
+        }
+    }
 }

--- a/src/frontend/core/typecheck/checker.rs
+++ b/src/frontend/core/typecheck/checker.rs
@@ -39,6 +39,14 @@ pub struct TypeChecker {
     /// 用户模块命名空间别名表（别名 → 模块限定键），由 `use lib` / `use lib as l` 整体导入登记。
     /// 模块解析归 typecheck 所有：IR 生成直接消费此表，不再自行从 AST 重新推导。
     module_namespaces: HashMap<String, String>,
+    /// RFC-004: 类型体绑定的待登记队列（类型名, 绑定, span）。
+    /// pass1 收集类型定义，此时被绑函数可能尚未注册（pass2 收集签名），
+    /// 故 External/DefaultExternal 延迟到 pass2 之后统一登记。
+    pending_body_bindings: Vec<(
+        String,
+        crate::frontend::core::parser::ast::TypeBodyBinding,
+        crate::util::span::Span,
+    )>,
 }
 
 impl TypeChecker {
@@ -62,6 +70,7 @@ impl TypeChecker {
             semantic_db: semantic_db::SemanticDB::new(),
             dependent_type_env,
             module_namespaces: HashMap::new(),
+            pending_body_bindings: Vec::new(),
         }
     }
 
@@ -221,6 +230,8 @@ impl TypeChecker {
         for stmt in &module.items {
             self.collect_function_signature(stmt);
         }
+        // RFC-004: 函数签名就位后登记类型体绑定
+        self.flush_pending_body_bindings();
     }
 
     /// 检查整个模块的内部实现
@@ -246,6 +257,9 @@ impl TypeChecker {
         for stmt in &module.items {
             self.collect_function_signature(stmt);
         }
+
+        // RFC-004: 函数签名就位后登记类型体绑定
+        self.flush_pending_body_bindings();
 
         // 收集所有导出项
         self.collect_exports(module);
@@ -967,6 +981,7 @@ impl TypeChecker {
             crate::frontend::core::parser::ast::StmtKind::Assign {
                 target,
                 value: Some(val),
+                span,
                 ..
             } => {
                 let (type_name, method_name) = match target.as_ref() {
@@ -1004,53 +1019,143 @@ impl TypeChecker {
                     _ => return,
                 };
                 if let Some(poly) = self.env.get_var(&func_name) {
-                    let method_ty = if positions.len() <= 1 {
-                        poly.body.clone()
-                    } else {
-                        match &poly.body {
-                            MonoType::Fn {
-                                params,
-                                return_type,
-                            } => {
-                                let mut new_params: Vec<MonoType> = Vec::new();
-                                for (i, p) in params.iter().enumerate() {
-                                    if !positions.contains(&(i as i64)) {
-                                        new_params.push(p.clone());
-                                    }
-                                }
-                                MonoType::Fn {
-                                    params: new_params,
-                                    return_type: return_type.clone(),
-                                }
-                            }
-                            other => other.clone(),
-                        }
+                    let total = match &poly.body {
+                        MonoType::Fn { params, .. } => params.len(),
+                        _ => 0,
                     };
-                    self.env
-                        .add_method_binding(&type_name, &method_name, method_ty);
+                    let fn_ty = poly.body.clone();
+                    if let Some(positions) =
+                        self.normalize_binding_positions(&positions, total, *span)
+                    {
+                        let method_ty = Self::method_type_after_binding(&fn_ty, &positions);
+                        self.env
+                            .add_method_binding(&type_name, &method_name, method_ty);
+                    }
                 }
             }
             _ => {}
         }
     }
 
+    /// RFC-004: 归一化绑定位置（负索引从末尾计数，[-1] = 最后一个参数）并校验有效性。
+    /// total 为被绑函数参数个数；未知（0）时跳过归一化与校验。无效位置报 E1064。
+    fn normalize_binding_positions(
+        &mut self,
+        positions: &[i64],
+        total: usize,
+        span: crate::util::span::Span,
+    ) -> Option<Vec<i64>> {
+        if total == 0 {
+            return Some(positions.to_vec());
+        }
+        let total_i = total as i64;
+        let normalized: Vec<i64> = positions
+            .iter()
+            .map(|&p| if p < 0 { p + total_i } else { p })
+            .collect();
+        if normalized.iter().any(|&p| p < 0 || p >= total_i) {
+            self.add_error(
+                ErrorCodeDefinition::invalid_binding_position(&format!("{:?}", positions), total)
+                    .at(span)
+                    .build(),
+            );
+            return None;
+        }
+        Some(normalized)
+    }
+
+    /// RFC-004: 绑定后的方法类型——单位绑定时保留全签名（实例占住绑定参数位），
+    /// 多位绑定时挖掉被绑参数，剩余参数由调用点填充。
+    fn method_type_after_binding(
+        fn_ty: &MonoType,
+        positions: &[i64],
+    ) -> MonoType {
+        if positions.len() <= 1 {
+            return fn_ty.clone();
+        }
+        match fn_ty {
+            MonoType::Fn {
+                params,
+                return_type,
+            } => {
+                let new_params: Vec<MonoType> = params
+                    .iter()
+                    .enumerate()
+                    .filter(|(i, _)| !positions.contains(&(*i as i64)))
+                    .map(|(_, p)| p.clone())
+                    .collect();
+                MonoType::Fn {
+                    params: new_params,
+                    return_type: return_type.clone(),
+                }
+            }
+            other => other.clone(),
+        }
+    }
+
+    /// RFC-004: 登记类型体绑定的待处理队列（须在函数签名收集 pass2 之后调用）。
+    pub fn flush_pending_body_bindings(&mut self) {
+        let pending = std::mem::take(&mut self.pending_body_bindings);
+        for (type_name, binding, span) in pending {
+            match &binding.kind {
+                crate::frontend::core::parser::ast::BindingKind::External {
+                    function,
+                    positions,
+                } => {
+                    self.register_external_method_binding(
+                        &type_name,
+                        &binding.name,
+                        function,
+                        positions,
+                        span,
+                    );
+                }
+                crate::frontend::core::parser::ast::BindingKind::DefaultExternal { function } => {
+                    self.register_external_method_binding(
+                        &type_name,
+                        &binding.name,
+                        function,
+                        &[0],
+                        span,
+                    );
+                }
+                crate::frontend::core::parser::ast::BindingKind::Anonymous { .. } => {}
+            }
+        }
+    }
+
+    /// RFC-004: 将 `Type.method = fn[pos]` 形态的绑定登记到 method_bindings。
+    /// 函数尚未注册（前向引用）时静默跳过——与既有宽松行为一致。
+    fn register_external_method_binding(
+        &mut self,
+        type_name: &str,
+        method_name: &str,
+        func_name: &str,
+        positions: &[i64],
+        span: crate::util::span::Span,
+    ) {
+        let found = self.env.get_var(func_name).map(|poly| {
+            (
+                match &poly.body {
+                    MonoType::Fn { params, .. } => params.len(),
+                    _ => 0,
+                },
+                poly.body.clone(),
+            )
+        });
+        let Some((total, fn_ty)) = found else {
+            return;
+        };
+        if let Some(positions) = self.normalize_binding_positions(positions, total, span) {
+            let method_ty = Self::method_type_after_binding(&fn_ty, &positions);
+            self.env
+                .add_method_binding(type_name, method_name, method_ty);
+        }
+    }
+
     /// 从 Index 表达式的 index 部分提取位置列表
     fn extract_positions(index: &crate::frontend::core::parser::ast::Expr) -> Vec<i64> {
-        use crate::frontend::core::lexer::tokens::Literal;
-        match index {
-            Expr::Lit(Literal::Int(n), _) => vec![*n as i64],
-            Expr::Tuple(items, _) => items
-                .iter()
-                .filter_map(|e| {
-                    if let Expr::Lit(Literal::Int(n), _) = e {
-                        Some(*n as i64)
-                    } else {
-                        None
-                    }
-                })
-                .collect(),
-            _ => vec![0],
-        }
+        crate::frontend::core::parser::ast::Expr::extract_binding_positions(index)
     }
 
     /// 将模块注册为 Struct 类型（包含所有导出作为字段）
@@ -1221,6 +1326,47 @@ impl TypeChecker {
         self.env.add_type(name.to_string(), poly.clone());
         // 同时注册到 vars，使类型名可以在表达式中使用（如 Point(1.0, 2.0) 构造器调用）
         self.env.add_var(name.to_string(), poly.clone());
+
+        // RFC-004: 类型体内的方法绑定登记到 method_bindings（与语句级 Type.method = fn[pos]
+        // 同一语义）。此前类型体 Binding 项只有 IR 侧登记，方法调用在类型检查层报 E1042。
+        if let crate::frontend::core::parser::ast::Type::Struct { body } = definition {
+            for item in body {
+                if let crate::frontend::core::parser::ast::TypeBodyItem::Binding(b) = item {
+                    match &b.kind {
+                        crate::frontend::core::parser::ast::BindingKind::External { .. }
+                        | crate::frontend::core::parser::ast::BindingKind::DefaultExternal {
+                            ..
+                        } => {
+                            // 被绑函数可能在其后定义，延迟到 pass2 之后登记
+                            self.pending_body_bindings
+                                .push((name.to_string(), b.clone(), span));
+                        }
+                        crate::frontend::core::parser::ast::BindingKind::Anonymous {
+                            params,
+                            return_type,
+                            positions,
+                            ..
+                        } => {
+                            // 匿名绑定：函数类型来自内置声明的注解
+                            let fn_ty = MonoType::Fn {
+                                params: params
+                                    .iter()
+                                    .filter_map(|p| p.ty.as_ref())
+                                    .map(|t| MonoType::from(t.clone()))
+                                    .collect(),
+                                return_type: Box::new(MonoType::from((**return_type).clone())),
+                            };
+                            if let Some(positions) =
+                                self.normalize_binding_positions(positions, params.len(), span)
+                            {
+                                let method_ty = Self::method_type_after_binding(&fn_ty, &positions);
+                                self.env.add_method_binding(name, &b.name, method_ty);
+                            }
+                        }
+                    }
+                }
+            }
+        }
 
         // RFC-027 Phase 2.5: 带约束表达式的类型定义同时注册为 proof 函数
         // IsPositive: (x: Int) -> Type = { x > 0 }

--- a/src/frontend/core/typecheck/checker.rs
+++ b/src/frontend/core/typecheck/checker.rs
@@ -20,6 +20,7 @@ use super::semantic_db;
 use crate::frontend::core::spawn;
 use super::types::TypeCheckResult;
 use super::environment::TypeEnvironment;
+use super::environment::ImplementationProof;
 use super::{add_builtin_types, add_std_traits, add_native_function_types};
 use super::Diagnostic;
 use crate::util::diagnostic::ErrorCodeDefinition;
@@ -47,6 +48,22 @@ pub struct TypeChecker {
         crate::frontend::core::parser::ast::TypeBodyBinding,
         crate::util::span::Span,
     )>,
+    /// RFC-011a: 已注册类型定义的 AST 体项（接口展开需要原始应用项；
+    /// MonoType 转换会丢弃 Expr/Binding 项，故单独留存）。
+    type_definition_bodies: HashMap<String, Vec<crate::frontend::core::parser::ast::TypeBodyItem>>,
+    /// RFC-011a: 类型体中的接口实例化待决记录（阶段 2 延迟完整性检查）。
+    pending_interface_instantiations: Vec<PendingInterfaceInstantiation>,
+    /// RFC-011a §3: 已声明方法签名 (类型名, 方法名) -> 签名。
+    /// 同签名重复声明 = 覆盖 → E1100；不同签名 = 重载 → 放行。
+    declared_methods: HashMap<(String, String), MonoType>,
+}
+
+/// RFC-011a: 类型体应用项 `Animal(Dog)` 的待决接口实例化。
+struct PendingInterfaceInstantiation {
+    impl_type: String,
+    interface_name: String,
+    args: Vec<crate::frontend::core::parser::ast::Type>,
+    span: crate::util::span::Span,
 }
 
 impl TypeChecker {
@@ -71,7 +88,16 @@ impl TypeChecker {
             dependent_type_env,
             module_namespaces: HashMap::new(),
             pending_body_bindings: Vec::new(),
+            type_definition_bodies: HashMap::new(),
+            pending_interface_instantiations: Vec::new(),
+            declared_methods: HashMap::new(),
         }
+    }
+
+    /// RFC-011a: 已通过的接口实现证明（编译期，运行时擦除）。
+    /// LSP/阶段 3 动态分发的类型收集据此枚举某接口的全部实现类型。
+    pub fn implementation_proofs(&self) -> &[ImplementationProof] {
+        &self.env.implementation_proofs
     }
 
     /// 注册预定义的 const 函数
@@ -260,6 +286,9 @@ impl TypeChecker {
 
         // RFC-004: 函数签名就位后登记类型体绑定
         self.flush_pending_body_bindings();
+
+        // RFC-011a 阶段2: 接口实例化完整性检查（Self 替换 + 签名匹配 + 实现证明）
+        self.finalize_interface_instantiations();
 
         // 收集所有导出项
         self.collect_exports(module);
@@ -873,6 +902,19 @@ impl TypeChecker {
 
                 // 如果有 type_name（显式方法绑定），使用 add_fn_binding
                 if type_name.is_some() {
+                    // RFC-011a §3: 同签名重复声明 = 覆盖 → E1100；不同签名 = 重载 → 放行
+                    let tn = type_name.as_deref().unwrap_or_default();
+                    let key = (tn.to_string(), name.clone());
+                    if let Some(prev) = self.declared_methods.get(&key) {
+                        if *prev == fn_ty {
+                            self.add_error(
+                                ErrorCodeDefinition::interface_method_duplicate(tn, &name)
+                                    .at(stmt.span)
+                                    .build(),
+                            );
+                        }
+                    }
+                    self.declared_methods.insert(key, fn_ty.clone());
                     self.env
                         .add_fn_binding(&name, type_name.as_deref(), fn_ty.clone());
                 } else {
@@ -1122,6 +1164,245 @@ impl TypeChecker {
                 crate::frontend::core::parser::ast::BindingKind::Anonymous { .. } => {}
             }
         }
+    }
+
+    /// RFC-011a 阶段1: 判断类型体应用项是否为接口实例化形态——
+    /// head 命中已注册类型构造器（generic_type_defs）且实参全为类型形态。
+    fn is_interface_application(
+        &self,
+        ty: &crate::frontend::core::parser::ast::Type,
+    ) -> bool {
+        use crate::frontend::core::parser::ast::Type;
+        if let Type::Generic {
+            name: head, args, ..
+        } = ty
+        {
+            let all_type_args = args.iter().all(|a| {
+                matches!(
+                    a,
+                    Type::Name { .. }
+                        | Type::Generic { .. }
+                        | Type::MetaType { .. }
+                        | Type::Ref { .. }
+                )
+            });
+            return all_type_args && self.env.generic_type_defs.contains_key(head);
+        }
+        false
+    }
+
+    /// RFC-011a: 类型实参是否引用给定参数名（抽象引用 → 继承链接，不记待决实例化）
+    fn type_arg_references(
+        ty: &crate::frontend::core::parser::ast::Type,
+        params: &[String],
+    ) -> bool {
+        use crate::frontend::core::parser::ast::Type;
+        match ty {
+            Type::Name { name, .. } => params.contains(name),
+            Type::Generic { args, .. } => args.iter().any(|a| Self::type_arg_references(a, params)),
+            Type::Ref { inner, .. } => Self::type_arg_references(inner, params),
+            _ => false,
+        }
+    }
+
+    /// RFC-011a 阶段2: 接口实例化完整性检查（须在 pass2 与类型体绑定登记之后调用）。
+    /// 五步流程（§1）：识别（pass1 已记录）→ Self 替换展开 → 签名匹配 →
+    /// 通过则登记 ImplementationProof → 失败报编译错误。
+    pub fn finalize_interface_instantiations(&mut self) {
+        let pending = std::mem::take(&mut self.pending_interface_instantiations);
+        for inst in pending {
+            let args: Vec<MonoType> = inst
+                .args
+                .iter()
+                .map(|a| MonoType::from(a.clone()))
+                .collect();
+            let _ = self.check_interface_instantiation(
+                &inst.impl_type,
+                &inst.interface_name,
+                &args,
+                inst.span,
+            );
+        }
+    }
+
+    /// RFC-011a: 展开接口成员列表（递归支持接口继承，Self 延迟替换）。
+    /// 返回 (方法名, 替换后签名)；同名成员后者覆盖前者。
+    fn expand_interface_members(
+        &mut self,
+        interface_name: &str,
+        args: &[MonoType],
+        visiting: &mut Vec<String>,
+        span: crate::util::span::Span,
+    ) -> Result<Vec<(String, MonoType)>, ()> {
+        use crate::frontend::core::parser::ast::Type;
+        if visiting.iter().any(|v| v == interface_name) {
+            // 循环继承：终止该分支展开
+            return Ok(Vec::new());
+        }
+        visiting.push(interface_name.to_string());
+
+        let Some(param_names) = self
+            .env
+            .generic_type_defs
+            .get(interface_name)
+            .map(|d| d.type_param_names.clone())
+        else {
+            self.add_error(
+                ErrorCodeDefinition::unknown_interface(interface_name)
+                    .at(span)
+                    .build(),
+            );
+            return Err(());
+        };
+        if param_names.len() != args.len() {
+            self.add_error(
+                ErrorCodeDefinition::interface_arity_mismatch(
+                    interface_name,
+                    param_names.len(),
+                    args.len(),
+                )
+                .at(span)
+                .build(),
+            );
+            return Err(());
+        }
+        let Some(body) = self.type_definition_bodies.get(interface_name).cloned() else {
+            visiting.pop();
+            return Ok(Vec::new());
+        };
+
+        let mut members: Vec<(String, MonoType)> = Vec::new();
+        for item in &body {
+            match item {
+                TypeBodyItem::Field(f) => {
+                    let ty = MonoType::from(f.ty.clone());
+                    let ty = TypeEnvironment::replace_type_params(&ty, &param_names, args);
+                    if !matches!(ty, MonoType::Fn { .. }) {
+                        // RFC-011a §1: 接口成员必须是方法（函数类型字段）
+                        self.add_error(
+                            ErrorCodeDefinition::interface_method_mismatch(
+                                interface_name,
+                                &f.name,
+                                "函数类型",
+                                &ty.to_string(),
+                            )
+                            .at(span)
+                            .build(),
+                        );
+                        return Err(());
+                    }
+                    members.push((f.name.clone(), ty));
+                }
+                TypeBodyItem::Expr(Type::Generic {
+                    name: head,
+                    args: nested_args,
+                    ..
+                }) => {
+                    // 接口继承：先替换当前接口类型参数再递归展开（Self 延迟替换）
+                    let nested: Vec<MonoType> = nested_args
+                        .iter()
+                        .map(|a| {
+                            let m = MonoType::from(a.clone());
+                            TypeEnvironment::replace_type_params(&m, &param_names, args)
+                        })
+                        .collect();
+                    match self.expand_interface_members(head, &nested, visiting, span) {
+                        Ok(sub) => members.extend(sub),
+                        Err(()) => return Err(()),
+                    }
+                }
+                _ => {}
+            }
+        }
+        visiting.pop();
+        Ok(members)
+    }
+
+    /// RFC-011a 阶段2: 对单个接口实例化做完整性检查并登记实现证明。
+    fn check_interface_instantiation(
+        &mut self,
+        impl_type: &str,
+        interface_name: &str,
+        args: &[MonoType],
+        span: crate::util::span::Span,
+    ) -> Result<(), ()> {
+        let mut visiting = Vec::new();
+        let members = self.expand_interface_members(interface_name, args, &mut visiting, span)?;
+
+        // §1.2 命名空间共享：接口方法名与实现类型已有字段同名 → 冲突
+        let impl_field_names: Vec<String> = match self.env.types.get(impl_type) {
+            Some(poly) => match &poly.body {
+                MonoType::Struct(s) => s.fields.iter().map(|(n, _)| n.clone()).collect(),
+                _ => Vec::new(),
+            },
+            None => Vec::new(),
+        };
+        for (member, _) in &members {
+            if impl_field_names.contains(member) {
+                self.add_error(
+                    ErrorCodeDefinition::interface_member_conflict(impl_type, member)
+                        .at(span)
+                        .build(),
+                );
+                return Err(());
+            }
+        }
+
+        // 完整性检查：每个接口成员须有同名实现且 Self 替换后签名一致
+        let mut methods: Vec<String> = Vec::new();
+        for (member, expected) in &members {
+            let Some(found) = self.env.get_method_binding(impl_type, member).cloned() else {
+                self.add_error(
+                    ErrorCodeDefinition::interface_method_missing(
+                        impl_type,
+                        interface_name,
+                        member,
+                    )
+                    .at(span)
+                    .build(),
+                );
+                return Err(());
+            };
+            if &found != expected {
+                self.add_error(
+                    ErrorCodeDefinition::interface_method_mismatch(
+                        impl_type,
+                        member,
+                        &expected.to_string(),
+                        &found.to_string(),
+                    )
+                    .at(span)
+                    .build(),
+                );
+                return Err(());
+            }
+            methods.push(member.clone());
+        }
+
+        // 通过 → 生成实现证明（纯编译期概念，运行时擦除，§5.3/§6.4）
+        self.env.implementation_proofs.push(ImplementationProof {
+            type_name: impl_type.to_string(),
+            interface_name: interface_name.to_string(),
+            methods,
+        });
+
+        // 接口名追加进实现类型的 interfaces 面（LSP/阶段3 类型收集消费）
+        let poly = self.env.types.get(impl_type);
+        if let Some(poly) = poly {
+            if let MonoType::Struct(s) = &poly.body {
+                let mut s = s.clone();
+                if !s.interfaces.iter().any(|i| i == interface_name) {
+                    s.interfaces.push(interface_name.to_string());
+                    let updated = PolyType {
+                        type_binders: poly.type_binders.clone(),
+                        const_binders: poly.const_binders.clone(),
+                        body: MonoType::Struct(s),
+                    };
+                    self.env.types.insert(impl_type.to_string(), updated);
+                }
+            }
+        }
+        Ok(())
     }
 
     /// RFC-004: 将 `Type.method = fn[pos]` 形态的绑定登记到 method_bindings。
@@ -1396,6 +1677,48 @@ impl TypeChecker {
             }
         }
 
+        // RFC-011a 阶段1: 类型体 AST 项留存（接口展开需要原始应用项，MonoType 转换会丢弃）
+        if let crate::frontend::core::parser::ast::Type::Struct { body } = definition {
+            self.type_definition_bodies
+                .insert(name.to_string(), body.clone());
+        }
+
+        // RFC-011a 阶段1: 类型体应用项语义改判。
+        // `Name(args)`（Expr(Generic)）命中已注册类型构造器且实参全为类型 → 接口实例化，
+        // 记入待决队列，阶段 2 统一做 Self 替换 + 完整性检查；实参引用本声明的类型参数
+        // （如接口继承体内的 Animal(Self)）为抽象链接，不记待检查（展开时延迟替换）。
+        // 其余应用项维持 const 约束路径（Assert(N > 0) 等），行为不变。
+        if let crate::frontend::core::parser::ast::Type::Struct { body } = definition {
+            let enclosing_params: Vec<String> =
+                generic_params.iter().map(|p| p.name.clone()).collect();
+            for item in body {
+                if let crate::frontend::core::parser::ast::TypeBodyItem::Expr(ty) = item {
+                    if self.is_interface_application(ty) {
+                        if let crate::frontend::core::parser::ast::Type::Generic {
+                            name: head,
+                            args,
+                            ..
+                        } = ty
+                        {
+                            let abstract_ref = args
+                                .iter()
+                                .any(|a| Self::type_arg_references(a, &enclosing_params));
+                            if !abstract_ref {
+                                self.pending_interface_instantiations.push(
+                                    PendingInterfaceInstantiation {
+                                        impl_type: name.to_string(),
+                                        interface_name: head.clone(),
+                                        args: args.clone(),
+                                        span,
+                                    },
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         // 如果是泛型类型构造器（有泛型参数），存储模板信息用于类型实例化
         if !generic_params.is_empty() {
             use crate::frontend::core::typecheck::environment::GenericTypeDef;
@@ -1437,12 +1760,14 @@ impl TypeChecker {
             let mut const_binders: Vec<ConstVarDef> = resolved_const.const_binders;
 
             // 从类型体收集待定证明义务到 const 参数
+            // （接口实例化应用项已被分流，不走 const 约束路径）
             if let crate::frontend::core::parser::ast::Type::Struct { body } = definition {
                 for item in body {
                     match item {
-                        TypeBodyItem::Expr(ty) => {
+                        TypeBodyItem::Expr(ty) if !self.is_interface_application(ty) => {
                             process_body_expr_item(ty, &mut const_binders);
                         }
+                        TypeBodyItem::Expr(_) => {}
                         TypeBodyItem::Field(f) => {
                             process_body_expr_item(&f.ty, &mut const_binders);
                         }

--- a/src/frontend/core/typecheck/environment.rs
+++ b/src/frontend/core/typecheck/environment.rs
@@ -28,6 +28,19 @@ pub struct GenericTypeDef {
     pub type_param_names: Vec<String>,
 }
 
+/// RFC-011a §5.3: 实现证明——某类型完整实现了某接口的编译期凭证。
+/// 纯编译期概念，运行时擦除（RFC-011a §6.4）；阶段 3 动态分发的类型收集
+/// 将以此为依据枚举某接口的全部实现类型。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImplementationProof {
+    /// 实现类型名（如 "Dog"）
+    pub type_name: String,
+    /// 接口名（如 "Animal"）
+    pub interface_name: String,
+    /// 已验证签名匹配的方法名列表
+    pub methods: Vec<String>,
+}
+
 /// 类型环境
 ///
 /// 存储类型检查过程中的所有状态信息：
@@ -68,6 +81,8 @@ pub struct TypeEnvironment {
     /// 方法绑定关系: "Type.method" -> FunctionType
     /// 用于存储显式绑定和 pub 自动绑定
     pub method_bindings: HashMap<String, MonoType>,
+    /// RFC-011a: 已通过的接口实现证明（编译期，运行时擦除）
+    pub implementation_proofs: Vec<ImplementationProof>,
     /// 模块名称
     pub module_name: String,
     /// 重载候选存储: 函数名 -> 多个重载版本
@@ -313,7 +328,7 @@ impl TypeEnvironment {
     }
 
     /// 替换类型参数：将 TypeRef(param_name) 替换为具体的类型实参
-    fn replace_type_params(
+    pub(crate) fn replace_type_params(
         ty: &MonoType,
         param_names: &[String],
         args: &[MonoType],

--- a/src/frontend/core/typecheck/tests/mod.rs
+++ b/src/frontend/core/typecheck/tests/mod.rs
@@ -23,6 +23,7 @@ mod gamma_assume_effect;
 mod predicate_resolver;
 mod rfc010;
 mod rfc011;
+mod rfc011a;
 mod rfc027_phase1_integration;
 mod rfc027_phase25_proof_fn;
 mod rfc027_phase2_smt;

--- a/src/frontend/core/typecheck/tests/rfc011a.rs
+++ b/src/frontend/core/typecheck/tests/rfc011a.rs
@@ -1,0 +1,309 @@
+//! 接口实现测试 — 基于 RFC-011a 接口实现与动态分发设计（#307）
+//!
+//! RFC-011a: docs/src/design/rfc/accepted/011a-interface-implementation.md
+//!
+//! 测试点：
+//! - §1: 接口声明（参数化类型）与类型体实例化（Self 替换展开）
+//! - §1: 完整性检查五步流程 → ImplementationProof（§5.3）
+//! - §1.2: 字段/方法命名空间冲突
+//! - §3: 同签名重复实现（覆盖）禁止
+//! - 接口继承：Self 延迟替换递归展开
+//!
+//! 接口机制 = 类型内自动柯里化：`Animal(Dog)` 实例化后成员
+//! `speak: (self: Self) -> String` 变为 `speak: (self: Dog) -> String`，
+//! 实例占住参数位、剩余参数柯里化（RFC-004 位置绑定语义）。
+
+use crate::frontend::core::typecheck::checker::TypeChecker;
+use crate::frontend::core::lexer::tokenize;
+use crate::frontend::core::parser::parse;
+
+/// 辅助函数：解析源代码并类型检查，同时返回 checker 以检查实现证明
+fn check_source_with_checker(
+    source: &str
+) -> (
+    crate::frontend::core::typecheck::types::TypeCheckResult,
+    TypeChecker,
+) {
+    let tokens = tokenize(source).expect("tokenize failed");
+    let result = parse(&tokens);
+    assert!(!result.has_errors, "parse failed: {:?}", result.errors);
+    let module = result.module;
+    let mut checker = TypeChecker::new("test");
+    let result = checker.check_module(&module);
+    (result, checker)
+}
+
+/// 辅助函数：只关心诊断结果
+fn check_source(source: &str) -> crate::frontend::core::typecheck::types::TypeCheckResult {
+    check_source_with_checker(source).0
+}
+
+const ANIMAL_DOG_FULL: &str = r#"
+    Animal: (Self: Type) -> Type = {
+        speak: (self: Self) -> String,
+        age: (self: Self) -> Int,
+    }
+    Dog: Type = {
+        name: String,
+        Animal(Dog),
+    }
+    Dog.speak: (self: Dog) -> String = {
+        return "Woof"
+    }
+    Dog.age: (self: Dog) -> Int = {
+        return 3
+    }
+"#;
+
+// RFC-011a §1: 接口实例化与实现证明
+
+/// 规范：接口实例化成功 → 生成 ImplementationProof
+///
+/// 预期行为：
+/// - Self ↦ Dog 替换展开接口体，签名匹配通过
+/// - checker 记录 {Dog, Animal, [speak, age]} 实现证明
+#[test]
+fn test_rfc011a_interface_instantiation_generates_proof() {
+    let (result, checker) = check_source_with_checker(ANIMAL_DOG_FULL);
+    assert!(
+        result.diagnostics.is_empty(),
+        "complete implementation should pass: {:?}",
+        result.diagnostics
+    );
+    let proofs = checker.implementation_proofs();
+    let proof = proofs
+        .iter()
+        .find(|p| p.type_name == "Dog" && p.interface_name == "Animal")
+        .expect("Dog should have an Animal implementation proof");
+    assert_eq!(proof.methods.len(), 2, "both members proven");
+    assert!(proof.methods.contains(&"speak".to_string()));
+    assert!(proof.methods.contains(&"age".to_string()));
+}
+
+/// 规范：接口方法未实现 → E1098（完整性检查失败）
+#[test]
+fn test_rfc011a_missing_method_reports_e1098() {
+    let source = r#"
+        Animal: (Self: Type) -> Type = {
+            speak: (self: Self) -> String,
+        }
+        Dog: Type = {
+            name: String,
+            Animal(Dog),
+        }
+    "#;
+    let result = check_source(source);
+    assert!(
+        result.diagnostics.iter().any(|d| d.code == "E1098"),
+        "missing implementation should report E1098: {:?}",
+        result.diagnostics
+    );
+}
+
+/// 规范：接口方法签名不匹配 → E1099
+#[test]
+fn test_rfc011a_signature_mismatch_reports_e1099() {
+    let source = r#"
+        Animal: (Self: Type) -> Type = {
+            speak: (self: Self) -> String,
+        }
+        Dog: Type = {
+            name: String,
+            Animal(Dog),
+        }
+        Dog.speak: (self: Dog) -> Int = {
+            return 42
+        }
+    "#;
+    let result = check_source(source);
+    assert!(
+        result.diagnostics.iter().any(|d| d.code == "E1099"),
+        "signature mismatch should report E1099: {:?}",
+        result.diagnostics
+    );
+}
+
+// RFC-011a §1.2: 命名空间共享
+
+/// 规范：接口方法名与类型字段同名 → E1097
+#[test]
+fn test_rfc011a_member_field_conflict_reports_e1097() {
+    let source = r#"
+        Animal: (Self: Type) -> Type = {
+            name: (self: Self) -> String,
+        }
+        Dog: Type = {
+            name: String,
+            Animal(Dog),
+        }
+    "#;
+    let result = check_source(source);
+    assert!(
+        result.diagnostics.iter().any(|d| d.code == "E1097"),
+        "field/method namespace conflict should report E1097: {:?}",
+        result.diagnostics
+    );
+}
+
+// RFC-011a §3: 覆盖禁止
+
+/// 规范：同签名方法重复声明 → E1100
+#[test]
+fn test_rfc011a_duplicate_impl_reports_e1100() {
+    let source = r#"
+        Animal: (Self: Type) -> Type = {
+            speak: (self: Self) -> String,
+        }
+        Dog: Type = {
+            name: String,
+            Animal(Dog),
+        }
+        Dog.speak: (self: Dog) -> String = {
+            return "Woof"
+        }
+        Dog.speak: (self: Dog) -> String = {
+            return "Bark"
+        }
+    "#;
+    let result = check_source(source);
+    assert!(
+        result.diagnostics.iter().any(|d| d.code == "E1100"),
+        "same-signature duplicate declaration should report E1100: {:?}",
+        result.diagnostics
+    );
+}
+
+/// 规范：不同签名同名方法 = 重载 → 放行（§3）
+#[test]
+fn test_rfc011a_overload_different_signature_allowed() {
+    let source = r#"
+        Dog: Type = {
+            name: String,
+        }
+        Dog.speak: (self: Dog) -> String = {
+            return "Woof"
+        }
+        Dog.speak: (self: Dog, times: Int) -> String = {
+            return "Woof"
+        }
+    "#;
+    let result = check_source(source);
+    let has_e1100 = result.diagnostics.iter().any(|d| d.code == "E1100");
+    assert!(
+        !has_e1100,
+        "different signatures are overloads, not overrides: {:?}",
+        result.diagnostics
+    );
+}
+
+// 接口继承：Self 延迟替换
+
+/// 规范：接口继承 Pet: Animal(Self) → Pet(Dog) 递归展开为 Animal(Dog)
+///
+/// 预期行为：
+/// - Dog 须同时实现 speak（继承自 Animal）与 fetch（Pet 自有）
+/// - 实现证明登记为 {Dog, Pet}
+#[test]
+fn test_rfc011a_inheritance_expands_recursively() {
+    let source = r#"
+        Animal: (Self: Type) -> Type = {
+            speak: (self: Self) -> String,
+        }
+        Pet: (Self: Type) -> Type = {
+            Animal(Self),
+            fetch: (self: Self) -> String,
+        }
+        Dog: Type = {
+            name: String,
+            Pet(Dog),
+        }
+        Dog.speak: (self: Dog) -> String = {
+            return "Woof"
+        }
+        Dog.fetch: (self: Dog) -> String = {
+            return self.name + " fetches"
+        }
+    "#;
+    let (result, checker) = check_source_with_checker(source);
+    assert!(
+        result.diagnostics.is_empty(),
+        "inherited contract should pass: {:?}",
+        result.diagnostics
+    );
+    let proof = checker
+        .implementation_proofs()
+        .iter()
+        .find(|p| p.type_name == "Dog" && p.interface_name == "Pet")
+        .expect("Dog should have a Pet proof via recursive expansion");
+    assert_eq!(proof.methods.len(), 2, "inherited + own members proven");
+}
+
+/// 规范：继承链成员缺失同样报完整性错误
+#[test]
+fn test_rfc011a_inherited_member_missing_reports_e1098() {
+    let source = r#"
+        Animal: (Self: Type) -> Type = {
+            speak: (self: Self) -> String,
+        }
+        Pet: (Self: Type) -> Type = {
+            Animal(Self),
+            fetch: (self: Self) -> String,
+        }
+        Dog: Type = {
+            name: String,
+            Pet(Dog),
+        }
+        Dog.fetch: (self: Dog) -> String = {
+            return "ball"
+        }
+    "#;
+    let result = check_source(source);
+    assert!(
+        result.diagnostics.iter().any(|d| d.code == "E1098"),
+        "missing inherited member should report E1098: {:?}",
+        result.diagnostics
+    );
+}
+
+/// 规范：继承链内引用未注册类型 → E1095
+#[test]
+fn test_rfc011a_unknown_interface_in_chain_reports_e1095() {
+    let source = r#"
+        Pet: (Self: Type) -> Type = {
+            Ghost(Self),
+            fetch: (self: Self) -> String,
+        }
+        Dog: Type = {
+            name: String,
+            Pet(Dog),
+        }
+        Dog.fetch: (self: Dog) -> String = {
+            return "ball"
+        }
+    "#;
+    let result = check_source(source);
+    assert!(
+        result.diagnostics.iter().any(|d| d.code == "E1095"),
+        "unknown interface in inheritance chain should report E1095: {:?}",
+        result.diagnostics
+    );
+}
+
+/// 规范：不完整实现不产生证明
+#[test]
+fn test_rfc011a_no_proof_on_failed_check() {
+    let source = r#"
+        Animal: (Self: Type) -> Type = {
+            speak: (self: Self) -> String,
+        }
+        Dog: Type = {
+            name: String,
+            Animal(Dog),
+        }
+    "#;
+    let (_result, checker) = check_source_with_checker(source);
+    assert!(
+        checker.implementation_proofs().is_empty(),
+        "failed completeness check must not generate proof"
+    );
+}

--- a/src/middle/core/ir_gen.rs
+++ b/src/middle/core/ir_gen.rs
@@ -1011,6 +1011,31 @@ impl AstToIrGenerator {
                         signature_params,
                     );
                 if let Some(type_name) = type_name {
+                    // RFC-004 外部重绑定：`Type.method = fn` / `Type.method = fn[pos]`
+                    // 只登记 type_bindings（方法调用时参数重排），不生成新函数 IR。
+                    let rebind = match value.as_deref() {
+                        Some(Expr::Var(fn_name, _)) => Some((fn_name.clone(), vec![0i64])),
+                        Some(Expr::Index { expr, index, .. }) => match expr.as_ref() {
+                            Expr::Var(fn_name, _) => {
+                                Some((fn_name.clone(), ast::Expr::extract_binding_positions(index)))
+                            }
+                            _ => None,
+                        },
+                        _ => None,
+                    };
+                    if let Some((function, positions)) = rebind {
+                        self.register_type_bindings(
+                            &type_name,
+                            &[ast::TypeBodyBinding {
+                                name: name.clone(),
+                                kind: ast::BindingKind::External {
+                                    function,
+                                    positions,
+                                },
+                            }],
+                        );
+                        return Ok(None);
+                    }
                     // MethodBind
                     self.generate_method_ir(
                         &type_name,
@@ -3610,13 +3635,20 @@ impl AstToIrGenerator {
                                 method_arg_regs.push(Operand::Local(arg_reg));
                             }
 
-                            // 按绑定位置重排参数
+                            // 按绑定位置重排参数。
+                            // total_params = 绑定位数 + 方法实参数 = 被绑函数元数（调用方
+                            // 恰好提供剩余参数），负索引据此归一化（[-1] = 最后一个参数）。
                             let total_params = binding.positions.len() + method_arg_regs.len();
+                            let positions: Vec<i64> = binding
+                                .positions
+                                .iter()
+                                .map(|&p| if p < 0 { p + total_params as i64 } else { p })
+                                .collect();
                             let mut final_args: Vec<Operand> = Vec::with_capacity(total_params);
                             let mut method_arg_iter = method_arg_regs.into_iter();
 
                             for pos in 0..total_params {
-                                if binding.positions.contains(&(pos as i64)) {
+                                if positions.contains(&(pos as i64)) {
                                     final_args.push(Operand::Local(obj_reg));
                                 } else if let Some(arg_reg) = method_arg_iter.next() {
                                     final_args.push(arg_reg);

--- a/src/util/diagnostic/codes/e1xxx.rs
+++ b/src/util/diagnostic/codes/e1xxx.rs
@@ -106,6 +106,12 @@ pub static E1XXX: &[ErrorCodeDefinition] = &[
         code: "W1063",
         category: ErrorCategory::TypeCheck,
     },
+    // === RFC-004 方法绑定 ===
+    // E1064: 绑定位置索引无效（越界或归一化后仍为负）
+    ErrorCodeDefinition {
+        code: "E1064",
+        category: ErrorCategory::TypeCheck,
+    },
     // === 控制流 ===
     ErrorCodeDefinition {
         code: "E1070",
@@ -153,6 +159,37 @@ pub static E1XXX: &[ErrorCodeDefinition] = &[
     },
     ErrorCodeDefinition {
         code: "E1094",
+        category: ErrorCategory::TypeCheck,
+    },
+    // === RFC-011a: 接口实例化 ===
+    // E1095: 未知接口（类型体引用的名字不是已注册的类型构造器）
+    ErrorCodeDefinition {
+        code: "E1095",
+        category: ErrorCategory::TypeCheck,
+    },
+    // E1096: 接口实例化类型实参个数不匹配
+    ErrorCodeDefinition {
+        code: "E1096",
+        category: ErrorCategory::TypeCheck,
+    },
+    // E1097: 接口成员与类型已有字段/方法共享命名空间（§1.2）
+    ErrorCodeDefinition {
+        code: "E1097",
+        category: ErrorCategory::TypeCheck,
+    },
+    // E1098: 接口方法未实现（完整性检查失败）
+    ErrorCodeDefinition {
+        code: "E1098",
+        category: ErrorCategory::TypeCheck,
+    },
+    // E1099: 接口方法签名与实现签名不匹配
+    ErrorCodeDefinition {
+        code: "E1099",
+        category: ErrorCategory::TypeCheck,
+    },
+    // E1100: 同签名接口方法重复实现（覆盖，§3 禁止）
+    ErrorCodeDefinition {
+        code: "E1100",
         category: ErrorCategory::TypeCheck,
     },
 ];
@@ -227,5 +264,19 @@ impl ErrorCodeDefinition {
     ("E1094", unused_const_param(param: &str, type_: &str) => .param("param", param) .param("type", type_)),
     /// E1090 彩蛋（返回占位符，由 i18n 的 zen_message 提供实际消息）
     ("E1090", type_self_reference_easter_egg() => ),
+    /// E1064 绑定位置索引无效（RFC-004）
+    ("E1064", invalid_binding_position(positions: &str, total: usize) => .param("positions", positions) .param("total", total.to_string())),
+    /// E1095 未知接口（RFC-011a）
+    ("E1095", unknown_interface(name: &str) => .param("name", name)),
+    /// E1096 接口实例化类型实参个数不匹配（RFC-011a）
+    ("E1096", interface_arity_mismatch(name: &str, expected: usize, found: usize) => .param("name", name) .param("expected", expected.to_string()) .param("found", found.to_string())),
+    /// E1097 接口成员与类型已有字段共享命名空间（RFC-011a §1.2）
+    ("E1097", interface_member_conflict(type_: &str, member: &str) => .param("type", type_) .param("member", member)),
+    /// E1098 接口方法未实现（RFC-011a 完整性检查）
+    ("E1098", interface_method_missing(type_: &str, interface: &str, method: &str) => .param("type", type_) .param("interface", interface) .param("method", method)),
+    /// E1099 接口方法签名不匹配（RFC-011a）
+    ("E1099", interface_method_mismatch(type_: &str, method: &str, expected: &str, found: &str) => .param("type", type_) .param("method", method) .param("expected", expected) .param("found", found)),
+    /// E1100 同签名接口方法重复实现（RFC-011a §3 覆盖禁止）
+    ("E1100", interface_method_duplicate(type_: &str, method: &str) => .param("type", type_) .param("method", method)),
     }
 }

--- a/tests/yaoxiang/02-type-system/interface_inheritance.yx
+++ b/tests/yaoxiang/02-type-system/interface_inheritance.yx
@@ -1,0 +1,38 @@
+// 02-type-system/interface_inheritance.yx
+// 覆盖: SPEC type-system.md §6 接口继承（RFC-011a，#307 阶段2）
+// 验证:
+//   - 接口继承无新语法：Pet 体内实例化 Animal(Self)，Self 延迟替换
+//   - Pet(Dog) 递归展开为 Animal(Dog) + Pet 自有成员
+//   - 实现类型须同时提供继承链上全部接口方法
+// 状态: ✅
+
+use std.assert
+
+Animal: (Self: Type) -> Type = {
+    speak: (self: Self) -> String,
+}
+
+// 接口继承：体内实例化 Animal(Self)，Pet(Dog) 时 Self ↦ Dog 再展开 Animal(Dog)
+Pet: (Self: Type) -> Type = {
+    Animal(Self),
+    fetch: (self: Self) -> String,
+}
+
+Dog: Type = {
+    name: String,
+    Pet(Dog),
+}
+
+Dog.speak: (self: Dog) -> String = {
+    return "Woof"
+}
+
+Dog.fetch: (self: Dog) -> String = {
+    return self.name + " fetches"
+}
+
+main = {
+    d = Dog("Rex")
+    assert.assert(d.speak() == "Woof", "inherited Animal.speak dispatches")
+    assert.assert(d.fetch() == "Rex fetches", "own Pet.fetch dispatches")
+}

--- a/tests/yaoxiang/02-type-system/interface_instantiate.yx
+++ b/tests/yaoxiang/02-type-system/interface_instantiate.yx
@@ -1,0 +1,38 @@
+// 02-type-system/interface_instantiate.yx
+// 覆盖: SPEC type-system.md §6 接口（RFC-011a §1/§2，#307 阶段1-2）
+// 验证:
+//   - 接口声明为参数化类型：Animal: (Self: Type) -> Type，Self 是显式类型参数
+//   - 类型体接口实例化 Animal(Dog)：Self ↦ Dog 替换展开接口体
+//   - 完整性检查通过后生成 ImplementationProof（编译期，运行时擦除）
+//   - dog.speak() 经既有 method_bindings 机制静态分发
+// 状态: ✅
+
+use std.assert
+
+// 接口：参数化类型，Self 是显式类型参数，成员为方法（函数类型字段）
+Animal: (Self: Type) -> Type = {
+    speak: (self: Self) -> String,
+    age: (self: Self) -> Int,
+}
+
+// 实现：类型体内接口实例化
+Dog: Type = {
+    name: String,
+    Animal(Dog),
+}
+
+// 方法实现：外部声明，实例占住 self 参数位（类型内自动柯里化）
+Dog.speak: (self: Dog) -> String = {
+    return "Woof"
+}
+
+Dog.age: (self: Dog) -> Int = {
+    return 3
+}
+
+main = {
+    d = Dog("Rex")
+    assert.assert(d.speak() == "Woof", "Animal.speak dispatch returns Woof")
+    assert.assert(d.age() == 3, "Animal.age dispatch returns 3")
+    assert.assert(d.name == "Rex", "own field still accessible")
+}

--- a/tests/yaoxiang/06-compile-errors/interface_duplicate_impl.yx
+++ b/tests/yaoxiang/06-compile-errors/interface_duplicate_impl.yx
@@ -1,0 +1,28 @@
+// 06-compile-errors/interface_duplicate_impl.yx
+// [test:error]: 同签名接口方法重复实现——签名完全相同的覆盖禁止（RFC-011a §3）
+// 验证: 重复实现 → E1100
+// 状态: ✅
+
+use std.assert
+
+Animal: (Self: Type) -> Type = {
+    speak: (self: Self) -> String,
+}
+
+Dog: Type = {
+    name: String,
+    Animal(Dog),
+}
+
+Dog.speak: (self: Dog) -> String = {
+    return "Woof"
+}
+
+Dog.speak: (self: Dog) -> String = {
+    return "Bark"
+}
+
+main = {
+    d = Dog("Rex")
+    assert.assert(d.speak() == "Woof", "duplicate impl must not compile")
+}

--- a/tests/yaoxiang/06-compile-errors/interface_member_conflict.yx
+++ b/tests/yaoxiang/06-compile-errors/interface_member_conflict.yx
@@ -1,0 +1,24 @@
+// 06-compile-errors/interface_member_conflict.yx
+// [test:error]: 接口方法与类型已有字段共享命名空间（RFC-011a §1.2）
+// 验证: point.x 与 point.x() 语法不可区分 → 接口方法名撞字段名 → E1097
+// 状态: ✅
+
+use std.assert
+
+Animal: (Self: Type) -> Type = {
+    name: (self: Self) -> String,
+}
+
+Dog: Type = {
+    name: String,
+    Animal(Dog),
+}
+
+Dog.name: (self: Dog) -> String = {
+    return self.name
+}
+
+main = {
+    d = Dog("Rex")
+    assert.assert(d.name == "Rex", "member/field conflict must not compile")
+}

--- a/tests/yaoxiang/06-compile-errors/interface_missing_method.yx
+++ b/tests/yaoxiang/06-compile-errors/interface_missing_method.yx
@@ -1,0 +1,20 @@
+// 06-compile-errors/interface_missing_method.yx
+// [test:error]: 接口方法未实现——Dog 实例化 Animal 却缺 speak 实现
+// 验证: 完整性检查失败 → E1098（RFC-011a §1 五步流程之第 5 步）
+// 状态: ✅
+
+use std.assert
+
+Animal: (Self: Type) -> Type = {
+    speak: (self: Self) -> String,
+}
+
+Dog: Type = {
+    name: String,
+    Animal(Dog),
+}
+
+main = {
+    d = Dog("Rex")
+    assert.assert(d.name == "Rex", "field access unaffected, but compile must fail")
+}

--- a/tests/yaoxiang/06-compile-errors/interface_signature_mismatch.yx
+++ b/tests/yaoxiang/06-compile-errors/interface_signature_mismatch.yx
@@ -1,0 +1,24 @@
+// 06-compile-errors/interface_signature_mismatch.yx
+// [test:error]: 接口方法签名不匹配——实现返回 Int 而接口（Self 替换后）要求 String
+// 验证: 签名匹配失败 → E1099（RFC-011a §1 五步流程之第 4 步失败）
+// 状态: ✅
+
+use std.assert
+
+Animal: (Self: Type) -> Type = {
+    speak: (self: Self) -> String,
+}
+
+Dog: Type = {
+    name: String,
+    Animal(Dog),
+}
+
+Dog.speak: (self: Dog) -> Int = {
+    return 42
+}
+
+main = {
+    d = Dog("Rex")
+    assert.assert(d.speak() == 42, "mismatched impl must not compile")
+}


### PR DESCRIPTION
Closes #307 的阶段 0-2（阶段 3 动态分发另行实施）。

接口 = 参数化类型的类型内自动柯里化：`Animal: (Self: Type) -> Type` 是类型级函数，`Animal(Dog)` 是实例化调用；`Self ↦ Dog` 替换后成员 `speak: (self: Self) -> String` 变为 `speak: (self: Dog) -> String`——实例占住参数位、剩余参数柯里化（RFC-004 位置绑定语义，无需手写 `[n]`）。

## 阶段 0：RFC-004 `[n]` 绑定全链路审计（结论 + 修复）

| 环节 | 审计结论 |
|---|---|
| 负索引 `[-1]` | ❌ 两端均未消费：typecheck 剥参与 IR 重排（`pos in 0..total`）永不命中负值 → **已修复**（按被绑函数元数归一化，越界报 E1064） |
| 语句级重绑定 `Type.method = fn[pos]` | ❌ IR 层 `type_annotation.unwrap()` 直接 panic（无类型注解形态从未跑通 E2E）→ **已修复**（Assign 处理器新增外部重绑定路径） |
| 类型体 `name = fn[pos]` | ❌ typecheck 从不登记 Binding 项，方法调用报 E1042 → **已修复**（pass1 收集待决队列，pass2 后统一登记，支持前向引用） |
| `DefaultExternal` 自动位置推导 | ⚠️ 两处硬编码 `vec![0]` → **评估后维持固化**：IR 层无签名预收集，前向引用场景不可靠；行为已在注释中如实记录 |
| `parse_method_bind` | 死代码（无人调用），语句级绑定实际由通用 Assign 解析器处理，其 `signature_params` 恒空无实际影响 |
| E2E 覆盖 | `[n]` 绑定此前零 E2E 测试 → 补齐三种形态验证（语句级 `[1]`/`[-1]`、类型体 `[-1]`） |

泛型替换四套并存，接口展开选用按名替换 `replace_type_params`（递归 Struct fields/Fn）。

## 阶段 1：类型体应用项语义改判

- `Animal(Dog)`（`Expr(Type::Generic)`）head 命中已注册类型构造器且实参全为类型形态 → 分流为接口实例化；`Assert(N > 0)` 等 const 约束路径行为不变
- 实参引用本声明类型参数（接口继承体内的 `Animal(Self)`）识别为抽象链接，展开时延迟替换
- 留存类型定义 AST 体项（MonoType 转换会丢弃应用项）

## 阶段 2：Self 替换 + 完整性检查 + ImplementationProof

- **延迟检查**：外部方法声明可在类型定义之后，pass1 仅记录待决实例化，pass2 + 类型体绑定登记后统一检查（对齐 RFC-011a §5.4）
- **Self 替换展开**：`replace_type_params` 逐成员替换，递归支持接口继承（`Pet: { Animal(Self), ... }`），循环继承有环守卫
- **完整性检查**：成员缺失 **E1098**、签名不匹配 **E1099**、接口方法与字段命名冲突 **E1097**（§1.2）、同签名重复实现（覆盖禁止）**E1100**（§3）、继承链未知接口 **E1095**、实参个数不符 **E1096**
- **ImplementationProof**（§5.3）：通过后登记 `{type_name, interface_name, methods}`，纯编译期、运行时擦除；接口名追加进实现类型 `interfaces` 面，为阶段 3 类型收集预留读取口
- **分发零 IR 改动**：`dog.speak()` 经既有 method_bindings 五路分发机制静态直调

## 测试

- 单测 `rfc011a.rs` 10 项（证明生成/缺失/不匹配/冲突/覆盖/重载放行/继承递归/继承缺失/未知接口/失败无证明）
- E2E 6 项：`interface_instantiate.yx`、`interface_inheritance.yx` + 4 项 `[test:error]`（E1098/E1099/E1100/E1097）
- `cargo test` 全绿（1779 lib + 48 + 174 + 2 + 5，无回归）

## 已知边界（后续）

- 阶段 3 动态分发（`List(Animal)` 存在类型、编译期类型收集 + 枚举包装）需新增 IR 指令，另行实施
- 默认值/默认方法体（RFC-011a §4、默认方法）未实现
- 跨模块接口实例化、泛型实现类型的接口实例化（`Box: (T: Type) -> Type = { ..., Animal(T) }`）暂不支持
- 直接体项引用未注册名（`Ghost(Dog)`）维持旧行为静默跳过，仅继承链内报 E1095